### PR TITLE
Add VDR scaffolding with libcharts and Python bindings

### DIFF
--- a/.github/workflows/vdr.yml
+++ b/.github/workflows/vdr.yml
@@ -1,0 +1,34 @@
+name: VDR CI
+
+on:
+  push:
+    paths:
+      - 'VDR/**'
+  pull_request:
+    paths:
+      - 'VDR/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++
+          pip install pybind11 pytest
+      - name: Build libcharts
+        run: |
+          cmake -S VDR/opencpn-libs -B VDR/opencpn-libs/build
+          cmake --build VDR/opencpn-libs/build
+      - name: Build charts_py
+        run: |
+          cd VDR/chart-tiler/charts_py
+          python setup.py build_ext --inplace
+      - name: Run tests
+        run: |
+          pytest VDR/chart-tiler/tests/test_generate_tile.py

--- a/VDR/Dockerfile
+++ b/VDR/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y cmake g++ && rm -rf /var/lib/apt/lists/*
+WORKDIR /workspace
+COPY opencpn-libs /workspace/opencpn-libs
+COPY chart-tiler /workspace/chart-tiler
+COPY web-client /workspace/web-client
+CMD ["bash"]

--- a/VDR/chart-tiler/charts_py/setup.py
+++ b/VDR/chart-tiler/charts_py/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup
+from pybind11.setup_helpers import Pybind11Extension, build_ext
+
+ext_modules = [
+    Pybind11Extension(
+        "charts_py._core",
+        ["src/bindings.cpp"],
+        include_dirs=["../../opencpn-libs/include"],
+        libraries=["charts"],
+        library_dirs=["../../opencpn-libs/build"],
+        runtime_library_dirs=["../../opencpn-libs/build"],
+    ),
+]
+
+setup(
+    name="charts_py",
+    version="0.0.1",
+    packages=["charts_py"],
+    package_dir={"": "src"},
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": build_ext},
+    zip_safe=False,
+)

--- a/VDR/chart-tiler/charts_py/src/bindings.cpp
+++ b/VDR/chart-tiler/charts_py/src/bindings.cpp
@@ -1,0 +1,29 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "charts.h"
+#include <array>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_core, m) {
+  m.doc() = "Python bindings for libcharts";
+  m.def("load_cell", &charts::load_cell, "Load a chart cell");
+  m.def(
+      "generate_tile",
+      [](std::array<double, 4> bbox, int z, const std::string& fmt,
+         const std::string& palette) {
+        if (fmt == "png") {
+          auto data = charts::render_tile_png(bbox[0], bbox[1], bbox[2],
+                                              bbox[3], z, palette);
+          return py::bytes(reinterpret_cast<const char*>(data.data()),
+                           data.size());
+        } else {
+          auto data =
+              charts::render_tile_mvt(bbox[0], bbox[1], bbox[2], bbox[3], z);
+          return py::bytes(reinterpret_cast<const char*>(data.data()),
+                           data.size());
+        }
+      },
+      py::arg("bbox"), py::arg("z"), py::arg("fmt") = "png",
+      py::arg("palette") = "day");
+}

--- a/VDR/chart-tiler/charts_py/src/charts_py/__init__.py
+++ b/VDR/chart-tiler/charts_py/src/charts_py/__init__.py
@@ -1,0 +1,2 @@
+from ._core import load_cell, generate_tile
+__all__ = ["load_cell", "generate_tile"]

--- a/VDR/chart-tiler/tests/test_generate_tile.py
+++ b/VDR/chart-tiler/tests/test_generate_tile.py
@@ -1,0 +1,33 @@
+import subprocess
+import sys
+from pathlib import Path
+import shutil
+import ctypes
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB_DIR = ROOT / "opencpn-libs"
+BUILD_DIR = LIB_DIR / "build"
+
+# Build C++ library
+subprocess.run(["cmake", "-S", str(LIB_DIR), "-B", str(BUILD_DIR)], check=True)
+subprocess.run(["cmake", "--build", str(BUILD_DIR)], check=True)
+
+# Build Python extension
+PKG_DIR = ROOT / "chart-tiler" / "charts_py"
+subprocess.run([sys.executable, "setup.py", "build_ext", "--inplace"], cwd=PKG_DIR, check=True)
+
+# copy library next to extension for runtime resolution
+for lib in ["libcharts.so", "libcharts.so.0", "libcharts.so.0.1.0"]:
+    shutil.copy(BUILD_DIR / lib, PKG_DIR / f"src/charts_py/{lib}")
+
+ctypes.CDLL(str(PKG_DIR / "src/charts_py/libcharts.so"))
+
+sys.path.insert(0, str(PKG_DIR / "src"))
+import charts_py
+
+def test_generate_tile(tmp_path):
+    sample = tmp_path / "dummy_cell.dat"
+    sample.write_bytes(b"DUMMY")
+    charts_py.load_cell(str(sample))
+    data = charts_py.generate_tile([0.0, 0.0, 1.0, 1.0], 0, fmt="png")
+    assert data.startswith(b"PNG")

--- a/VDR/docker-compose.yml
+++ b/VDR/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  chart-tiler:
+    build: .
+    working_dir: /workspace/chart-tiler
+    command: python -m charts_py
+  web-client:
+    image: node:18
+    working_dir: /app
+    volumes:
+      - ./web-client:/app
+    command: npm start

--- a/VDR/opencpn-libs/CMakeLists.txt
+++ b/VDR/opencpn-libs/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.10)
+project(opencpn_charts LANGUAGES CXX)
+
+add_library(charts SHARED
+    src/charts.cpp
+    src/cm93/dummy.cpp
+    src/s57chart/dummy.cpp
+    src/ps52plib/dummy.cpp
+)
+
+target_include_directories(charts PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+set_target_properties(charts PROPERTIES
+    OUTPUT_NAME "charts"
+    VERSION 0.1.0
+    SOVERSION 0
+)
+
+install(TARGETS charts DESTINATION lib)
+install(DIRECTORY include/ DESTINATION include)

--- a/VDR/opencpn-libs/include/charts.h
+++ b/VDR/opencpn-libs/include/charts.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <string>
+#include <vector>
+
+namespace charts {
+void load_cell(const std::string& path);
+std::vector<unsigned char> render_tile_png(double minx, double miny,
+                                           double maxx, double maxy, int z,
+                                           const std::string& palette = "day");
+std::vector<unsigned char> render_tile_mvt(double minx, double miny,
+                                           double maxx, double maxy, int z);
+}  // namespace charts

--- a/VDR/opencpn-libs/src/charts.cpp
+++ b/VDR/opencpn-libs/src/charts.cpp
@@ -1,0 +1,29 @@
+#include "charts.h"
+
+namespace charts {
+
+void load_cell(const std::string& path) { (void)path; }
+
+std::vector<unsigned char> render_tile_png(double minx, double miny,
+                                           double maxx, double maxy, int z,
+                                           const std::string& palette) {
+  (void)minx;
+  (void)miny;
+  (void)maxx;
+  (void)maxy;
+  (void)z;
+  (void)palette;
+  return std::vector<unsigned char>{'P', 'N', 'G'};
+}
+
+std::vector<unsigned char> render_tile_mvt(double minx, double miny,
+                                           double maxx, double maxy, int z) {
+  (void)minx;
+  (void)miny;
+  (void)maxx;
+  (void)maxy;
+  (void)z;
+  return std::vector<unsigned char>{'M', 'V', 'T'};
+}
+
+}  // namespace charts

--- a/VDR/opencpn-libs/src/cm93/dummy.cpp
+++ b/VDR/opencpn-libs/src/cm93/dummy.cpp
@@ -1,0 +1,1 @@
+void cm93_dummy() {}

--- a/VDR/opencpn-libs/src/ps52plib/dummy.cpp
+++ b/VDR/opencpn-libs/src/ps52plib/dummy.cpp
@@ -1,0 +1,1 @@
+void ps52_dummy() {}

--- a/VDR/opencpn-libs/src/s57chart/dummy.cpp
+++ b/VDR/opencpn-libs/src/s57chart/dummy.cpp
@@ -1,0 +1,1 @@
+void s57_dummy() {}

--- a/VDR/testdata/README.md
+++ b/VDR/testdata/README.md
@@ -1,0 +1,2 @@
+Binary CM93 and S-57 sample cells are omitted from this repository.
+Provide your own chart cells or generate dummy files during tests.

--- a/VDR/web-client/README.md
+++ b/VDR/web-client/README.md
@@ -1,0 +1,3 @@
+# Web Client
+
+Placeholder React client using MapLibre and deck.gl.

--- a/VDR/web-client/package.json
+++ b/VDR/web-client/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "web-client",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "maplibre-gl": "^2.4.0",
+    "deck.gl": "^8.9.0"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold VDR mono-repo with opencpn-libs, chart-tiler, and web-client
- build stub `libcharts` with CMake and expose pybind11 wrapper
- add test data, CI workflow, and Docker/compose helpers
- generate dummy chart cells at runtime so the repo avoids binary test fixtures

## Testing
- `pre-commit run --files VDR/chart-tiler/tests/test_generate_tile.py VDR/testdata/README.md`
- `pytest VDR/chart-tiler/tests/test_generate_tile.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689f5ddc9b28832a9c3dae13d75807e3