### PR TITLE
Document and harden chart tiler tooling

### DIFF
--- a/VDR/chart-tiler/README.md
+++ b/VDR/chart-tiler/README.md
@@ -27,6 +27,25 @@ populates a `charts.sqlite` database with `object_class`, `attribute_class` and
 python ingest_charts.py
 ```
 
+### SQLite schema
+
+The generated ``charts.sqlite`` contains three simple tables used by the tile
+server at runtime:
+
+``object_class``
+: ``id`` (integer primary key), ``acronym`` (e.g. ``BOYSPP``) and human readable
+  ``name``.
+
+``attribute_class``
+: ``id`` (integer primary key), ``acronym`` and ``name`` fields mirroring the
+  S‑57 attribute dictionary.
+
+``chart_metadata``
+: ``key``/``value`` pairs for global information such as the chart edition.
+
+Running the ingestion script multiple times is safe – rows are replaced on
+conflict, keeping the database idempotent.
+
 ## FastAPI tile service
 
 `tileserver.py` exposes `/tiles/{z}/{x}/{y}?fmt=png` (or `fmt=mvt`) using only

--- a/VDR/chart-tiler/ingest_charts.py
+++ b/VDR/chart-tiler/ingest_charts.py
@@ -1,51 +1,110 @@
-"""Populate an SQLite database with chart dictionary metadata.
+"""Utility for generating a chart dictionary SQLite database.
 
-The `charts_py` module exposes helpers returning entries for CM93/S‑57
-object classes, attribute classes and general chart metadata.  This script
-stores them in a small SQLite database for fast lookup at runtime.
+The :mod:`charts_py` module (implemented either by a lightweight Python
+fallback or the real ``libcharts`` bindings) exposes helpers returning
+metadata about S‑57/CM93 chart object classes, attribute classes and global
+chart properties.  ``ingest_charts.py`` persists this information to a small
+SQLite file for quick lookup by the tile server.
 
-Usage:
-    python ingest_charts.py [output_path]
+The resulting database contains three tables:
 
-The database defaults to `charts.sqlite` in the current directory.
+``object_class``
+    ``id`` (INTEGER PRIMARY KEY) – numeric identifier used in S‑57
+    ``acronym`` (TEXT) – short code such as ``BOYSPP``
+    ``name`` (TEXT) – human readable description
+
+``attribute_class``
+    ``id`` (INTEGER PRIMARY KEY)
+    ``acronym`` (TEXT)
+    ``name`` (TEXT)
+
+``chart_metadata``
+    ``key`` (TEXT PRIMARY KEY)
+    ``value`` (TEXT)
+
+Example
+-------
+>>> python ingest_charts.py charts.sqlite
+
+Parameters
+----------
+output : Path, optional
+    Location of the SQLite database to create.  Defaults to ``charts.sqlite``
+    in the current working directory.
 """
 from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from typing import Iterable, Tuple
+
 import charts_py
 
 
+def _create_schema(cur: sqlite3.Cursor) -> None:
+    """Create database tables if they do not yet exist."""
+
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS object_class (
+            id INTEGER PRIMARY KEY,
+            acronym TEXT NOT NULL,
+            name TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS attribute_class (
+            id INTEGER PRIMARY KEY,
+            acronym TEXT NOT NULL,
+            name TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS chart_metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _populate_table(cur: sqlite3.Cursor, table: str, rows: Iterable[Tuple]) -> None:
+    """Insert rows into *table* replacing existing entries.
+
+    ``INSERT OR REPLACE`` ensures rerunning the script updates records rather
+    than failing due to ``PRIMARY KEY`` conflicts.
+    """
+
+    placeholders = ",".join(["?"] * len(next(iter(rows), [])))
+    sql = f"INSERT OR REPLACE INTO {table} VALUES ({placeholders})"
+    cur.executemany(sql, rows)
+
+
 def main(db_path: Path) -> None:
-    conn = sqlite3.connect(db_path)
-    cur = conn.cursor()
+    """Populate *db_path* with chart dictionary metadata."""
 
-    cur.execute(
-        "CREATE TABLE IF NOT EXISTS object_class (id INTEGER PRIMARY KEY, acronym TEXT, name TEXT)"
-    )
-    cur.execute(
-        "CREATE TABLE IF NOT EXISTS attribute_class (id INTEGER PRIMARY KEY, acronym TEXT, name TEXT)"
-    )
-    cur.execute(
-        "CREATE TABLE IF NOT EXISTS chart_metadata (key TEXT PRIMARY KEY, value TEXT)"
-    )
-
-    cur.executemany("INSERT INTO object_class VALUES (?, ?, ?)", charts_py.get_object_classes())
-    cur.executemany(
-        "INSERT INTO attribute_class VALUES (?, ?, ?)", charts_py.get_attribute_classes()
-    )
-    cur.executemany("INSERT INTO chart_metadata VALUES (?, ?)", charts_py.get_chart_metadata())
-
-    conn.commit()
-    conn.close()
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.cursor()
+        _create_schema(cur)
+        _populate_table(cur, "object_class", charts_py.get_object_classes())
+        _populate_table(cur, "attribute_class", charts_py.get_attribute_classes())
+        _populate_table(cur, "chart_metadata", charts_py.get_chart_metadata())
+        conn.commit()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI convenience
     import argparse
 
-    parser = argparse.ArgumentParser(description="Ingest chart dictionaries into SQLite.")
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "output", nargs="?", default="charts.sqlite", help="Path to output SQLite DB"
+        "output",
+        nargs="?",
+        default="charts.sqlite",
+        type=Path,
+        help="Path to output SQLite database",
     )
-    args = parser.parse_args()
-    main(Path(args.output))
+    main(parser.parse_args().output)

--- a/VDR/chart-tiler/render_tile.py
+++ b/VDR/chart-tiler/render_tile.py
@@ -1,12 +1,22 @@
-"""Render a single chart tile to PNG for regression tests."""
+"""CLI utility for rendering a single chart tile to PNG.
+
+The script is intentionally tiny – it simply invokes
+``charts_py.generate_tile`` for a given Web‑Mercator tile coordinate and writes
+the resulting PNG to disk.  It is primarily used in automated tests where the
+output is compared against a baseline image.
+"""
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
 import math
+from pathlib import Path
+
 import charts_py
 
+
 def tile_bounds(x: int, y: int, z: int) -> list[float]:
+    """Return the bounding box for a Web‑Mercator tile."""
+
     n = 2 ** z
     lon_left = x / n * 360.0 - 180.0
     lon_right = (x + 1) / n * 360.0 - 180.0
@@ -14,17 +24,21 @@ def tile_bounds(x: int, y: int, z: int) -> list[float]:
     lat_bottom = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * (y + 1) / n))))
     return [lon_left, lat_bottom, lon_right, lat_top]
 
+
 def main(z: int, x: int, y: int, output: Path) -> None:
+    """Render tile ``(z, x, y)`` and write the PNG to *output*."""
+
     bbox = tile_bounds(x, y, z)
     opts = {"format": "png", "palette": "day", "safetyContour": 0.0}
     data = charts_py.generate_tile(bbox, z, opts)
     output.write_bytes(data)
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Render a chart tile to PNG")
-    parser.add_argument("z", type=int)
-    parser.add_argument("x", type=int)
-    parser.add_argument("y", type=int)
-    parser.add_argument("--output", default="tile.png", type=Path)
+
+if __name__ == "__main__":  # pragma: no cover - exercised via tests
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("z", type=int, help="Zoom level")
+    parser.add_argument("x", type=int, help="Tile column")
+    parser.add_argument("y", type=int, help="Tile row")
+    parser.add_argument("--output", default=Path("tile.png"), type=Path, help="Output PNG path")
     args = parser.parse_args()
     main(args.z, args.x, args.y, args.output)

--- a/VDR/chart-tiler/tests/test_tileserver.py
+++ b/VDR/chart-tiler/tests/test_tileserver.py
@@ -28,3 +28,14 @@ def test_metrics_endpoint():
     r = client.get("/metrics")
     assert r.status_code == 200
     assert b"tile_gen_ms" in r.content
+
+
+def test_cache_hits_metric():
+    import re
+
+    # First call primes the cache; second should be served from the LRU cache.
+    client.get("/tiles/cm93/0/0/0?fmt=png&palette=day&safetyContour=0")
+    client.get("/tiles/cm93/0/0/0?fmt=png&palette=day&safetyContour=0")
+    metrics = client.get("/metrics").text
+    match = re.search(r"cache_hits_total\s+(\d+)", metrics)
+    assert match and int(match.group(1)) >= 1

--- a/VDR/chart-tiler/tileserver.py
+++ b/VDR/chart-tiler/tileserver.py
@@ -1,12 +1,15 @@
-"""FastAPI service exposing chart tiles.
+"""FastAPI service exposing raster or vector chart tiles.
 
-Endpoints:
-    /tiles/{z}/{x}/{y}?fmt=png&pal=day
-    /metrics
+The application provides two HTTP endpoints:
 
-Tiles are cached in memory using an LRU strategy and optionally in Redis when
-`REDIS_URL` is set.  Prometheus metrics record tile generation times and cache
-hits.
+``/tiles/{z}/{x}/{y}``
+    Returns a tile in either PNG or Mapbox Vector Tile (``fmt=mvt``) format.
+    Tiles are cached using an in‑process LRU cache and optionally in Redis when
+    ``REDIS_URL`` is defined.  Both caches are tracked via Prometheus metrics.
+
+``/metrics``
+    Exposes Prometheus metrics including ``tile_gen_ms`` (time spent
+    generating tiles) and ``cache_hits``.
 """
 from __future__ import annotations
 
@@ -15,6 +18,8 @@ import math
 import os
 import time
 import logging
+from typing import Optional
+
 import charts_py
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -31,9 +36,15 @@ logger = logging.getLogger("tileserver")
 
 _tile_gen_ms = Histogram("tile_gen_ms", "Time spent generating tiles", unit="ms")
 _cache_hits = Counter("cache_hits", "Cache hits")
-_redis = redis.from_url(os.environ["REDIS_URL"]) if redis and "REDIS_URL" in os.environ else None
+_redis: Optional["redis.Redis"] = (
+    redis.from_url(os.environ["REDIS_URL"]) if redis and "REDIS_URL" in os.environ else None
+)
+_redis_ttl = int(os.environ.get("REDIS_TTL", "0"))  # seconds; 0 means no expiry
+
 
 def _tile_bounds(x: int, y: int, z: int) -> list[float]:
+    """Return the Web‑Mercator bounding box for a given tile."""
+
     n = 2 ** z
     lon_left = x / n * 360.0 - 180.0
     lon_right = (x + 1) / n * 360.0 - 180.0
@@ -41,12 +52,23 @@ def _tile_bounds(x: int, y: int, z: int) -> list[float]:
     lat_bottom = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * (y + 1) / n))))
     return [lon_left, lat_bottom, lon_right, lat_top]
 
+
 def _cache_key(z: int, x: int, y: int, fmt: str, pal: str, safety: float) -> str:
+    """Return a unique cache key for a tile request."""
+
     return f"{fmt}:{pal}:{safety}:{z}/{x}/{y}"
 
+
 @lru_cache(maxsize=512)
-def _render_tile(bbox_tuple: tuple[float, float, float, float], z: int, fmt: str,
-                 pal: str, safety: float) -> bytes:
+def _render_tile(
+    bbox_tuple: tuple[float, float, float, float],
+    z: int,
+    fmt: str,
+    pal: str,
+    safety: float,
+) -> bytes:
+    """Invoke :func:`charts_py.generate_tile` with Prometheus timing."""
+
     opts = {"format": fmt, "palette": pal, "safetyContour": safety}
     with _tile_gen_ms.time():
         return charts_py.generate_tile(list(bbox_tuple), z, opts)
@@ -60,6 +82,12 @@ def get_tile(
     palette: str = "day",
     safetyContour: float = 0.0,
 ) -> Response:
+    """Return a single chart tile.
+
+    Parameters mirror :func:`charts_py.generate_tile`.  When Redis is configured
+    tiles are stored with an optional TTL specified via ``REDIS_TTL``.
+    """
+
     key = _cache_key(z, x, y, fmt, palette, safetyContour)
     cache_status = "miss"
     if _redis:
@@ -70,8 +98,16 @@ def get_tile(
             media = "image/png" if fmt == "png" else "application/x-protobuf"
             logger.info(
                 "tile_request",
-                extra={"z": z, "x": x, "y": y, "fmt": fmt, "palette": palette,
-                       "safetyContour": safetyContour, "cache": cache_status, "ms": 0.0},
+                extra={
+                    "z": z,
+                    "x": x,
+                    "y": y,
+                    "fmt": fmt,
+                    "palette": palette,
+                    "safetyContour": safetyContour,
+                    "cache": cache_status,
+                    "ms": 0.0,
+                },
             )
             return Response(content=cached, media_type=media)
 
@@ -86,12 +122,20 @@ def get_tile(
         _cache_hits.inc()
 
     if _redis:
-        _redis.set(key, data)
+        _redis.set(key, data, ex=_redis_ttl or None)
 
     logger.info(
         "tile_request",
-        extra={"z": z, "x": x, "y": y, "fmt": fmt, "palette": palette,
-               "safetyContour": safetyContour, "cache": cache_status, "ms": ms},
+        extra={
+            "z": z,
+            "x": x,
+            "y": y,
+            "fmt": fmt,
+            "palette": palette,
+            "safetyContour": safetyContour,
+            "cache": cache_status,
+            "ms": ms,
+        },
     )
 
     media_type = "image/png" if fmt == "png" else "application/x-protobuf"
@@ -99,4 +143,6 @@ def get_tile(
 
 @app.get("/metrics")
 def metrics() -> Response:
+    """Return Prometheus metrics in the text exposition format."""
+
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)


### PR DESCRIPTION
## Summary
- document and robustly populate chart metadata via SQLite
- improve FastAPI tile server with TTL-aware Redis caching and detailed docs
- add tested cache hit metrics and expand CLI documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8825580c832a8cbe62d23772c859