### PR TITLE
chore: add S-52 asset sync tooling

### DIFF
--- a/VDR/server-styling/.gitignore
+++ b/VDR/server-styling/.gitignore
@@ -1,0 +1,4 @@
+# Generated OpenCPN S-52 assets
+opencpn-assets/
+style.s52.day.json
+sprites/

--- a/VDR/server-styling/README.md
+++ b/VDR/server-styling/README.md
@@ -9,3 +9,31 @@ server-styling/
   tiles/     # output chart tiles (e.g. COG, MBTiles)
 ```
 
+
+## S-52 assets
+
+The S-52 renderer depends on upstream symbol and lookup tables from the
+[OpenCPN](https://github.com/OpenCPN/OpenCPN) project.  To keep builds
+reproducible these files are fetched on demand based on the commit pinned in
+`opencpn-assets.lock`.
+
+```
+server-styling/
+  opencpn-assets.lock  # upstream repo/path/commit
+  opencpn-assets/      # populated by sync script (ignored by git)
+```
+
+Fetch the assets and generate the required MapLibre artifacts:
+
+```bash
+python VDR/server-styling/sync_opencpn_assets.py
+python VDR/server-styling/build_style_json.py \
+  --rulebook VDR/server-styling/opencpn-assets \
+  --output VDR/server-styling/style.s52.day.json
+python VDR/server-styling/generate_sprite_json.py \
+  --chartsymbols VDR/server-styling/opencpn-assets/chartsymbols.xml \
+  --output VDR/server-styling/sprites/s52-day.json
+```
+
+The generated `style.s52.day.json`, `sprites/s52-day.json` and upstream
+`rastersymbols-day.png` can then be served alongside vector tiles.

--- a/VDR/server-styling/generate_sprite_json.py
+++ b/VDR/server-styling/generate_sprite_json.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Generate a MapLibre sprite manifest from ``chartsymbols.xml``.
+
+The manifest describes the location and dimensions of each symbol within the
+atlas PNG used by MapLibre.  No image manipulation is performed; the original
+PNG from OpenCPN is used directly.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--chartsymbols", type=Path, required=True, help="Path to chartsymbols.xml")
+    parser.add_argument(
+        "--output", type=Path, required=True, help="Path to write sprite JSON manifest"
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    tree = ET.parse(args.chartsymbols)
+    root = tree.getroot()
+
+    sprites: dict[str, dict[str, int]] = {}
+
+    for symbol in root.findall(".//symbols/symbol"):
+        name_elem = symbol.find("name")
+        bitmap = symbol.find("bitmap")
+        if name_elem is None or bitmap is None:
+            continue
+        gl = bitmap.find("graphics-location")
+        if gl is None:
+            continue
+        try:
+            name = name_elem.text or ""
+            x = int(gl.get("x", "0"))
+            y = int(gl.get("y", "0"))
+            w = int(bitmap.get("width", "0"))
+            h = int(bitmap.get("height", "0"))
+        except ValueError:
+            continue
+        sprites[name] = {
+            "x": x,
+            "y": y,
+            "width": w,
+            "height": h,
+            "pixelRatio": 1,
+        }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as f:
+        json.dump(sprites, f, indent=2, sort_keys=True)
+    print(f"Wrote {len(sprites)} sprite entries to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/VDR/server-styling/opencpn-assets.lock
+++ b/VDR/server-styling/opencpn-assets.lock
@@ -1,0 +1,3 @@
+repo=https://github.com/OpenCPN/OpenCPN
+path=data/s57data
+commit=81ec5a47adb837b9c97be843db89b30d13393777

--- a/VDR/server-styling/sync_opencpn_assets.py
+++ b/VDR/server-styling/sync_opencpn_assets.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Fetch S-52 assets from the OpenCPN repository at a pinned commit.
+
+The repository/commit/path are read from ``opencpn-assets.lock``.  Only the
+required files are copied into ``opencpn-assets/`` and their size and sha256
+checksums are verified after copy.
+"""
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+LOCK_FILE = Path(__file__).with_name("opencpn-assets.lock")
+TARGET_DIR = Path(__file__).with_name("opencpn-assets")
+
+REQUIRED_FILES = {
+    "chartsymbols.xml",
+    "rastersymbols-day.png",
+    "S52RAZDS.RLE",
+}
+
+
+def _parse_lock() -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line in LOCK_FILE.read_text().splitlines():
+        if not line.strip():
+            continue
+        key, _, value = line.partition("=")
+        data[key.strip()] = value.strip()
+    missing = {k for k in ("repo", "path", "commit") if k not in data}
+    if missing:
+        raise ValueError(f"Missing keys in lock file: {', '.join(sorted(missing))}")
+    return data
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> None:
+    lock = _parse_lock()
+    repo = lock["repo"]
+    repo_path = lock["path"].strip("/")
+    commit = lock["commit"]
+
+    TARGET_DIR.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        # Fetch only the required commit depth-one
+        subprocess.run(["git", "init", tmpdir], check=True)
+        subprocess.run(["git", "-C", tmpdir, "remote", "add", "origin", repo], check=True)
+        subprocess.run(["git", "-C", tmpdir, "fetch", "--depth", "1", "origin", commit], check=True)
+        subprocess.run(["git", "-C", tmpdir, "checkout", commit], check=True)
+
+        src_base = tmp / repo_path
+        if not src_base.exists():
+            raise FileNotFoundError(f"Path '{repo_path}' not found in repo")
+
+        files = set(REQUIRED_FILES)
+        files.update(p.name for p in src_base.glob("*.csv"))
+
+        for name in sorted(files):
+            src = src_base / name
+            if not src.exists():
+                raise FileNotFoundError(f"Required asset '{name}' missing in upstream repo")
+            dst = TARGET_DIR / name
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            if src.stat().st_size != dst.stat().st_size:
+                raise RuntimeError(f"Size mismatch for '{name}'")
+            if _sha256(src) != _sha256(dst):
+                raise RuntimeError(f"Hash mismatch for '{name}'")
+            print(f"Fetched {name} ({dst.stat().st_size} bytes)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- pin OpenCPN S-52 assets via lock file
- add sync and sprite manifest generation scripts
- document how to fetch and build MapLibre style assets

## Testing
- `pre-commit run --files VDR/server-styling/README.md VDR/server-styling/.gitignore VDR/server-styling/generate_sprite_json.py VDR/server-styling/opencpn-assets.lock VDR/server-styling/sync_opencpn_assets.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'dbus')*

------
https://chatgpt.com/codex/tasks/task_e_689f919c4ddc832aa0979690f1538854