### PR TITLE
Implement server-side S-52 preclassification and MVT pipeline

### DIFF
--- a/VDR/chart-tiler/.github/workflows/mvt.yml
+++ b/VDR/chart-tiler/.github/workflows/mvt.yml
@@ -1,0 +1,22 @@
+name: chart-tiler mvt
+
+on:
+  push:
+    paths:
+      - 'VDR/chart-tiler/**'
+  pull_request:
+    paths:
+      - 'VDR/chart-tiler/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install deps
+        run: pip install -r VDR/chart-tiler/requirements.txt
+      - name: Run tests
+        run: pytest VDR/chart-tiler/tests -q

--- a/VDR/chart-tiler/datasource_stub.py
+++ b/VDR/chart-tiler/datasource_stub.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Deterministic synthetic datasource used for tests.
+
+The datasource generates a small set of GeoJSON‑like features within the
+provided bounding box.  The output is fully deterministic for a given tile
+(z/x/y) so that unit tests remain stable.
+"""
+
+from typing import Iterable, Dict, Any, Tuple, List
+
+BBox = Tuple[float, float, float, float]
+
+
+def _rect_polygon(x1: float, y1: float, x2: float, y2: float) -> List[List[List[float]]]:
+    """Return coordinates for a simple rectangle polygon."""
+
+    return [[[x1, y1], [x2, y1], [x2, y2], [x1, y2], [x1, y1]]]
+
+
+def features_for_tile(bbox: BBox, z: int, x: int, y: int) -> Iterable[Dict[str, Any]]:
+    """Yield deterministic features for the given tile.
+
+    The geometries are deliberately simple and only serve to exercise the
+    server pipeline.
+    """
+
+    minx, miny, maxx, maxy = bbox
+    midx = (minx + maxx) / 2.0
+    midy = (miny + maxy) / 2.0
+
+    # Land area covering left half of the tile -----------------------------
+    yield {
+        "geometry": {"type": "Polygon", "coordinates": _rect_polygon(minx, miny, midx, maxy)},
+        "properties": {"OBJL": "LNDARE"},
+    }
+
+    # Two depth areas on the water side -----------------------------------
+    # Shallow area
+    yield {
+        "geometry": {"type": "Polygon", "coordinates": _rect_polygon(midx, miny, maxx, midy)},
+        "properties": {"OBJL": "DEPARE", "DRVAL1": 0.0, "DRVAL2": 5.0},
+    }
+    # Deeper area which flips classification around common safety contours
+    yield {
+        "geometry": {"type": "Polygon", "coordinates": _rect_polygon(midx, midy, maxx, maxy)},
+        "properties": {"OBJL": "DEPARE", "DRVAL1": 10.0, "DRVAL2": 100.0},
+    }
+
+    # Depth contours with varying accuracy --------------------------------
+    vals = [5.0, 10.0, 15.0]
+    for i, v in enumerate(vals):
+        x_coord = midx + (i + 1) * (maxx - midx) / 4.0
+        yield {
+            "geometry": {"type": "LineString", "coordinates": [[x_coord, miny], [x_coord, maxy]]},
+            "properties": {
+                "OBJL": "DEPCNT",
+                "VALDCO": v,
+                "QUAPOS": 3 if i == 1 else 1,  # Second contour marked low accuracy
+            },
+        }
+
+    # Coastline separating land and water ---------------------------------
+    yield {
+        "geometry": {"type": "LineString", "coordinates": [[midx, miny], [midx, maxy]]},
+        "properties": {"OBJL": "COALNE"},
+    }
+
+    # Soundings with different depths -------------------------------------
+    sound_vals = [2.0, 15.0]
+    for i, val in enumerate(sound_vals):
+        sx = midx + (i + 1) * (maxx - midx) / 3.0
+        sy = miny + (i + 1) * (maxy - miny) / 3.0
+        yield {
+            "geometry": {"type": "Point", "coordinates": [sx, sy]},
+            "properties": {"OBJL": "SOUNDG", "VALSOU": val},
+        }

--- a/VDR/chart-tiler/mvt_builder.py
+++ b/VDR/chart-tiler/mvt_builder.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+"""Simple Mapbox Vector Tile encoder helper."""
+
+from typing import Iterable, Dict, Any
+
+from mapbox_vector_tile import encode as mvt_encode
+
+
+def encode_mvt(features: Iterable[Dict[str, Any]]) -> bytes:
+    """Encode features into a single-layer Mapbox Vector Tile."""
+
+    layer = {"name": "features", "features": list(features)}
+    return mvt_encode([layer])

--- a/VDR/chart-tiler/s52_preclass.py
+++ b/VDR/chart-tiler/s52_preclass.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Minimal S-52 Day palette pre-classification."""
+
+from typing import Dict, Any
+
+
+class S52PreClassifier:
+    """Apply a very small subset of S-52 conditional symbology rules."""
+
+    def __init__(self, chartsymbols_xml: str, sc: float, colors: Dict[str, str]):
+        self.sc = float(sc)
+        self.colors = colors
+        self.chartsymbols_xml = chartsymbols_xml
+        # Hooks for future use: lookups, priorities, etc.
+
+    def classify(self, objl: str, props: Dict[str, Any]) -> Dict[str, Any]:
+        """Return style helper attributes based on object and properties."""
+
+        if objl == "DEPARE":
+            d1 = props.get("DRVAL1")
+            d2 = props.get("DRVAL2")
+            values = [v for v in (d1, d2) if isinstance(v, (int, float))]
+            is_shallow = min(values) < self.sc if values else False
+            if is_shallow:
+                token = "DEPVS" if "DEPVS" in self.colors else "DEPIT1"
+                return {"fillToken": token, "isShallow": True}
+            max_val = max(values) if values else -9999
+            if max_val >= self.sc:
+                return {"fillToken": "DEPDW", "isShallow": False}
+            return {"isShallow": False}
+
+        if objl == "DEPCNT":
+            is_safety = float(props.get("VALDCO", -9999)) == self.sc
+            is_low_acc = float(props.get("QUAPOS", 0)) >= 2
+            return {"isSafety": is_safety, "isLowAcc": is_low_acc}
+
+        if objl == "SOUNDG":
+            valsou = props.get("VALSOU")
+            is_shallow = isinstance(valsou, (int, float)) and valsou < self.sc
+            return {"isShallow": is_shallow}
+
+        # LNDARE/COALNE and other objects use static styling
+        return {}

--- a/VDR/chart-tiler/tests/test_mvt_semantics.py
+++ b/VDR/chart-tiler/tests/test_mvt_semantics.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import base64
+import json
+import re
+from pathlib import Path
+import sys
+
+import mapbox_vector_tile
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+DIST = ROOT.parent / "server-styling" / "dist"
+
+# Ensure minimal assets exist for tileserver startup -----------------------
+(DIST / "sprites").mkdir(parents=True, exist_ok=True)
+(DIST / "assets" / "s52").mkdir(parents=True, exist_ok=True)
+
+(DIST / "style.s52.day.json").write_text(
+    json.dumps({"version": 8, "sources": {}, "layers": []})
+)
+(DIST / "sprites" / "s52-day.json").write_text("{}")
+(DIST / "assets" / "s52" / "rastersymbols-day.png").write_bytes(
+    base64.b64decode(
+        b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAgMBgNwK9+wAAAAASUVORK5CYII="
+    )
+)
+(DIST / "assets" / "s52" / "chartsymbols.xml").write_text(
+    "<root><color-table name='DAY_BRIGHT'><color name='DEPVS' r='1' g='2' b='3'/>"
+    "<color name='DEPDW' r='4' g='5' b='6'/></color-table></root>"
+)
+
+import tileserver
+
+client = TestClient(tileserver.app)
+
+
+def _decode(sc: float):
+    r = client.get(f"/tiles/cm93/0/0/0?fmt=mvt&sc={sc}")
+    assert r.status_code == 200
+    data = mapbox_vector_tile.decode(r.content)
+    return data["features"]["features"]
+
+
+def test_mvt_properties_present() -> None:
+    feats = _decode(10)
+    assert isinstance(feats, list)
+    for feat in feats:
+        assert isinstance(feat["properties"].get("OBJL"), str)
+
+
+def test_depare_banding_sc_switch() -> None:
+    f5 = _decode(5)
+    f50 = _decode(50)
+    toggled = False
+    for a, b in zip(f5, f50):
+        if a["properties"].get("OBJL") == "DEPARE" and b["properties"].get("OBJL") == "DEPARE":
+            if a["properties"].get("isShallow") != b["properties"].get("isShallow"):
+                toggled = True
+                break
+    assert toggled
+
+
+def test_depcnt_safety_lowacc() -> None:
+    feats = _decode(10)
+    assert any(f["properties"].get("isSafety") for f in feats if f["properties"].get("OBJL") == "DEPCNT")
+    assert any(f["properties"].get("isLowAcc") for f in feats if f["properties"].get("OBJL") == "DEPCNT")
+
+
+def test_soundg_threshold() -> None:
+    f5 = _decode(5)
+    f50 = _decode(50)
+    flipped = False
+    for a, b in zip(f5, f50):
+        if a["properties"].get("OBJL") == "SOUNDG" and b["properties"].get("OBJL") == "SOUNDG":
+            if a["properties"].get("isShallow") != b["properties"].get("isShallow"):
+                flipped = True
+                break
+    assert flipped
+
+
+def test_headers_and_cache() -> None:
+    client.get("/tiles/cm93/0/0/0?fmt=mvt&sc=9")
+    r2 = client.get("/tiles/cm93/0/0/0?fmt=mvt&sc=9")
+    assert r2.headers.get("X-Tile-Cache") == "hit"
+    metrics = client.get("/metrics").text
+    m = re.search(r"cache_hits_total (\d+)", metrics)
+    assert m and int(m.group(1)) >= 1

--- a/VDR/chart-tiler/tests/test_tileserver.py
+++ b/VDR/chart-tiler/tests/test_tileserver.py
@@ -41,6 +41,11 @@ DIST = ROOT.parent / "server-styling" / "dist"
         b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAgMBgNwK9+wAAAAASUVORK5CYII="
     )
 )
+# Minimal chartsymbols.xml for color parsing
+(DIST / "assets" / "s52" / "chartsymbols.xml").write_text(
+    "<root><color-table name='DAY_BRIGHT'><color name='DEPVS' r='1' g='2' b='3'/>"
+    "<color name='DEPDW' r='4' g='5' b='6'/></color-table></root>"
+)
 
 import tileserver
 

--- a/VDR/server-styling/.github/workflows/styling.yml
+++ b/VDR/server-styling/.github/workflows/styling.yml
@@ -40,6 +40,9 @@ jobs:
             --glyphs "/glyphs/{fontstack}/{range}.pbf" \
             --safety-contour 10 \
             --output VDR/server-styling/dist/style.s52.day.json
+      - name: Validate style
+        run: |
+          npx @maplibre/maplibre-gl-style-spec@latest validate VDR/server-styling/dist/style.s52.day.json
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/VDR/server-styling/build_style_json.py
+++ b/VDR/server-styling/build_style_json.py
@@ -85,6 +85,9 @@ def build_layers(
 
     layers: List[tuple[int, Dict[str, object]]] = []
 
+    if "DEPVS" not in colors:
+        print("Warning: DEPVS missing, using DEPIT1", file=sys.stderr)
+
     def prio(obj: str, default: int) -> int:
         return priorities.get(obj, default)
 
@@ -102,6 +105,7 @@ def build_layers(
                     "fill-color": get_colour(colors, "LANDA"),
                     "fill-outline-color": get_colour(colors, "CHBLK"),
                 },
+                "metadata": {"maplibre:s52": "LNDARE-LANDA"},
             },
         )
     )
@@ -121,6 +125,7 @@ def build_layers(
                     ["<", ["coalesce", ["get", "DRVAL2"], ["get", "DRVAL1"], 99999], sc],
                 ],
                 "paint": {"fill-color": get_colour(colors, "DEPVS", "DEPIT1")},
+                "metadata": {"maplibre:s52": "DEPARE-DEPVS"},
             },
         )
     )
@@ -142,6 +147,7 @@ def build_layers(
                     ],
                 ],
                 "paint": {"fill-color": get_colour(colors, "DEPDW")},
+                "metadata": {"maplibre:s52": "DEPARE-DEPDW"},
             },
         )
     )
@@ -157,6 +163,7 @@ def build_layers(
                 "source-layer": source_layer,
                 "filter": ["==", ["get", "OBJL"], "DEPCNT"],
                 "paint": {"line-color": get_colour(colors, "DEPCN"), "line-width": 1},
+                "metadata": {"maplibre:s52": "DEPCNT-DEPCN"},
             },
         )
     )
@@ -178,6 +185,7 @@ def build_layers(
                     "line-width": 1,
                     "line-dasharray": [2, 2],
                 },
+                "metadata": {"maplibre:s52": "DEPCNT-QUAPOS>=2"},
             },
         )
     )
@@ -198,6 +206,7 @@ def build_layers(
                     "line-color": get_colour(colors, "DEPSC"),
                     "line-width": 2,
                 },
+                "metadata": {"maplibre:s52": "DEPCNT-VALDCO==sc"},
             },
         )
     )
@@ -216,6 +225,7 @@ def build_layers(
                     "line-color": get_colour(colors, "CHBLK"),
                     "line-width": 1,
                 },
+                "metadata": {"maplibre:s52": "COALNE-CHBLK"},
             },
         )
     )
@@ -248,6 +258,7 @@ def build_layers(
                     "text-halo-color": "#ffffff",
                     "text-halo-width": 1,
                 },
+                "metadata": {"maplibre:s52": "SOUNDG"},
             },
         )
     )


### PR DESCRIPTION
## Summary
- add deterministic datasource stub and server-side S-52 Day pre-classifier
- replace placeholder vector tiles with real pre-classified MVT output and caching headers
- enrich generated style layers with S-52 metadata and validate style in CI
- add semantic tile tests and dedicated chart-tiler workflow

## Testing
- `pytest VDR/chart-tiler/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689fa0462334832a91887a59fd2e7cfc