### PR TITLE
feat(s52): prefix-safe icons and reliable style validation

### DIFF
--- a/VDR/chart-tiler/s52_preclass.py
+++ b/VDR/chart-tiler/s52_preclass.py
@@ -29,16 +29,17 @@ class S52PreClassifier:
             is_shallow = min(values) < self.sc if values else False
             if is_shallow:
                 token = "DEPVS" if "DEPVS" in self.colors else "DEPIT1"
-                return {"fillToken": token, "isShallow": True}
+                return {"fillToken": token, "isShallow": True, "depthBand": "VS"}
             max_val = max(values) if values else -9999
             if max_val >= self.sc:
-                return {"fillToken": "DEPDW", "isShallow": False}
-            return {"isShallow": False}
+                return {"fillToken": "DEPDW", "isShallow": False, "depthBand": "DW"}
+            return {"isShallow": False, "depthBand": "DW"}
 
         if objl == "DEPCNT":
             is_safety = float(props.get("VALDCO", -9999)) == self.sc
             is_low_acc = float(props.get("QUAPOS", 0)) >= 2
-            return {"isSafety": is_safety, "isLowAcc": is_low_acc}
+            role = "safety" if is_safety else "normal"
+            return {"isSafety": is_safety, "isLowAcc": is_low_acc, "role": role}
 
         if objl == "SOUNDG":
             valsou = props.get("VALSOU")

--- a/VDR/chart-tiler/tests/test_mvt_semantics.py
+++ b/VDR/chart-tiler/tests/test_mvt_semantics.py
@@ -126,6 +126,38 @@ def test_hazard_icon_present() -> None:
             assert icon in sprite
 
 
+def test_hazard_icon_prefixed() -> None:
+    (DIST / "sprites" / "s52-day.json").write_text(
+        json.dumps(
+            {
+                "s52-ISODGR51": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 1,
+                    "height": 1,
+                    "pixelRatio": 1,
+                    "sdf": False,
+                },
+                "s52-DANGER51": {
+                    "x": 1,
+                    "y": 0,
+                    "width": 1,
+                    "height": 1,
+                    "pixelRatio": 1,
+                    "sdf": False,
+                },
+            }
+        )
+    )
+    feats = _decode(10)
+    hazard_feats = [f for f in feats if f["properties"].get("OBJL") in ("WRECKS", "OBSTRN")]
+    sprite = json.loads((DIST / "sprites" / "s52-day.json").read_text())
+    assert any(
+        f["properties"].get("hazardIcon") and f"s52-{f['properties']['hazardIcon']}" in sprite
+        for f in hazard_feats
+    )
+
+
 def test_headers_and_cache() -> None:
     client.get("/tiles/cm93/0/0/0?fmt=mvt&sc=9")
     r2 = client.get("/tiles/cm93/0/0/0?fmt=mvt&sc=9")

--- a/VDR/server-styling/.github/workflows/styling.yml
+++ b/VDR/server-styling/.github/workflows/styling.yml
@@ -42,7 +42,8 @@ jobs:
             --output VDR/server-styling/dist/style.s52.day.json
       - name: Validate style
         run: |
-          npx @maplibre/maplibre-gl-style-spec@latest validate VDR/server-styling/dist/style.s52.day.json
+          npm install --no-save @maplibre/maplibre-gl-style-spec
+          node VDR/server-styling/tools/validate_style.mjs VDR/server-styling/dist/style.s52.day.json
       - name: Coverage summary
         run: |
           python VDR/server-styling/s52_coverage.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml

--- a/VDR/server-styling/build_style_json.py
+++ b/VDR/server-styling/build_style_json.py
@@ -213,8 +213,15 @@ def build_layers(
                     ["literal", ["OBSTRN", "WRECKS", "UWTROC", "ROCKS"]],
                 ],
                 "layout": {
-                    "icon-image": ["coalesce", ["get", "hazardIcon"], ""],
+                    "icon-image": [
+                        "case",
+                        ["has", "hazardIcon"],
+                        ["concat", "{SPRITE_PREFIX}", ["get", "hazardIcon"]],
+                        "",
+                    ],
                     "icon-allow-overlap": True,
+                    "icon-anchor": "center",
+                    "icon-offset": [0, 0],
                     "icon-size": 1.0,
                 },
                 "metadata": {"maplibre:s52": "UDWHAZ-hazardIcon"},
@@ -248,10 +255,10 @@ def build_layers(
                             ["to-number", ["coalesce", ["get", "VALSOU"], ["get", "VAL"]]],
                             sc,
                         ],
-                        "#353535",
-                        "#FFFFFF",
+                        get_colour(colors, "SNDG1", "#353535"),
+                        get_colour(colors, "SNDG2", "#FFFFFF"),
                     ],
-                    "text-halo-color": "#FFFFFF",
+                    "text-halo-color": get_colour(colors, "SNDG2", "#FFFFFF"),
                     "text-halo-width": 1,
                 },
                 "metadata": {"maplibre:s52": "SOUNDG"},
@@ -277,6 +284,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--sprite-base", required=True, help="Sprite base URL")
     p.add_argument("--glyphs", required=True, help="Glyphs URL template")
     p.add_argument("--safety-contour", type=float, default=0.0)
+    p.add_argument("--sprite-prefix", default="", help="Prefix for sprite names")
     p.add_argument("--output", type=Path, required=True)
     return p.parse_args()
 
@@ -318,7 +326,9 @@ def main() -> None:  # pragma: no cover - CLI wrapper
             _fail(f"Layer {lyr['id']} missing paint/layout")
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(style, indent=2, sort_keys=True))
+    style_json = json.dumps(style, indent=2, sort_keys=True)
+    style_json = style_json.replace("{SPRITE_PREFIX}", args.sprite_prefix)
+    args.output.write_text(style_json)
     print(f"Wrote style with {len(layers)} layers to {args.output}")
 
 

--- a/VDR/server-styling/s52_coverage.py
+++ b/VDR/server-styling/s52_coverage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -35,6 +36,48 @@ def main() -> None:  # pragma: no cover - CLI helper
     print(f"Lookups: {len(lookups)}")
     for name in ["ISODGR51", "DANGER51", "WRECKS01"]:
         print(f"Symbol {name}: {'yes' if name in symbols else 'no'}")
+
+    # Style coverage -------------------------------------------------------
+    style_path = Path(__file__).resolve().parent / "dist" / "style.s52.day.json"
+    coverage_dir = Path(__file__).resolve().parent / "dist" / "coverage"
+    tokens: list[str] = []
+    layers: list[dict[str, str]] = []
+    symbols_seen: set[str] = set()
+    if style_path.exists():
+        style = json.loads(style_path.read_text())
+        for lyr in style.get("layers", []):
+            token = lyr.get("metadata", {}).get("maplibre:s52")
+            if token:
+                tokens.append(token)
+                layers.append({"id": lyr.get("id", ""), "token": token})
+            icon = lyr.get("layout", {}).get("icon-image")
+            if isinstance(icon, str):
+                symbols_seen.add(icon)
+
+    lookup_objs = {l["objl"] for l in lookups}
+    style_objs = {t.split("-", 1)[0] for t in tokens}
+    covered = sorted(lookup_objs & style_objs)
+    missing = sorted(lookup_objs - style_objs)
+
+    coverage_dir.mkdir(parents=True, exist_ok=True)
+    (coverage_dir / "symbols_seen.txt").write_text("\n".join(sorted(symbols_seen)))
+    (coverage_dir / "style_coverage.json").write_text(
+        json.dumps(
+            {
+                "totalLookups": len(lookup_objs),
+                "coveredByStyle": len(covered),
+                "missingObjL": missing,
+                "layers": layers,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+    print("Style coverage:")
+    print(f"  total lookups: {len(lookup_objs)}")
+    print(f"  covered by style: {len(covered)}")
+    print(f"  missing: {len(missing)}")
 
 
 if __name__ == "__main__":

--- a/VDR/server-styling/tests/test_s52_xml.py
+++ b/VDR/server-styling/tests/test_s52_xml.py
@@ -6,6 +6,7 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / 'server-styling'))
 
 from s52_xml import parse_symbols, parse_linestyles, parse_lookups
+import pytest
 
 
 def test_chartsymbols_parsing():
@@ -19,3 +20,23 @@ def test_chartsymbols_parsing():
     objs = {l['objl'] for l in lookups}
     for name in ['DEPARE', 'DEPCNT', 'COALNE', 'SOUNDG']:
         assert name in objs
+
+
+def test_symbol_anchor_and_rotation():
+    path = ROOT / 'server-styling' / 'dist' / 'assets' / 's52' / 'chartsymbols.xml'
+    root = ET.parse(path).getroot()
+    symbols = parse_symbols(root)
+    sym = symbols.get('ISODGR51')
+    if not sym or 'anchor' not in sym:
+        pytest.skip('ISODGR51 anchor missing in this chartsymbols.xml')
+    assert sym['anchor'] == (9, 9)
+
+
+def test_symbol_rotation_flag():
+    path = ROOT / 'server-styling' / 'dist' / 'assets' / 's52' / 'chartsymbols.xml'
+    root = ET.parse(path).getroot()
+    symbols = parse_symbols(root)
+    sym = symbols.get('LITVES03')
+    if not sym or 'rotate' not in sym:
+        pytest.skip('LITVES03 rotation flag missing in this chartsymbols.xml')
+    assert sym['rotate'] is True

--- a/VDR/server-styling/tools/validate_style.mjs
+++ b/VDR/server-styling/tools/validate_style.mjs
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { validateStyleMin } from '@maplibre/maplibre-gl-style-spec';
+const path = process.argv[2];
+if (!path) {
+  console.error('Usage: node validate_style.mjs <style.json>');
+  process.exit(2);
+}
+const style = JSON.parse(readFileSync(path, 'utf8'));
+const result = validateStyleMin(style);
+if (Array.isArray(result) && result.length) {
+  console.error(JSON.stringify(result, null, 2));
+  process.exit(2);
+}
+console.log('OK');


### PR DESCRIPTION
## Summary
- add Node-based MapLibre style validator and wire into CI
- support sprite prefixes in style builder and hazard icons
- extend coverage reporting and classifier tags for future S-52 layers

## Testing
- `node VDR/server-styling/tools/validate_style.mjs VDR/server-styling/dist/style.s52.day.json`
- `python VDR/server-styling/s52_coverage.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml`
- `pytest VDR/server-styling/tests -q`
- `pytest VDR/chart-tiler/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689faa518e3c832a900cd2a0656f44ee