### PR TITLE
Phase 4: docs and hazard sprite offsets

### DIFF
--- a/VDR/chart-tiler/s52_preclass.py
+++ b/VDR/chart-tiler/s52_preclass.py
@@ -49,7 +49,17 @@ class S52PreClassifier:
         if objl in {"OBSTRN", "WRECKS", "UWTROC", "ROCKS"}:
             icon = self._hazard_icon(objl, props)
             if icon and (not self.symbols or icon in self.symbols):
-                return {"hazardIcon": icon}
+                result: Dict[str, Any] = {"hazardIcon": icon}
+                meta = self.symbols.get(icon) if self.symbols else None
+                if meta and meta.get("anchor"):
+                    w = meta.get("w", 0)
+                    h = meta.get("h", 0)
+                    ax, ay = meta["anchor"]
+                    offx = int(round(w / 2 - ax))
+                    offy = int(round(h / 2 - ay))
+                    result["hazardOffX"] = offx
+                    result["hazardOffY"] = offy
+                return result
             return {}
 
         # LNDARE/COALNE and other objects use static styling

--- a/VDR/chart-tiler/tests/test_mvt_semantics.py
+++ b/VDR/chart-tiler/tests/test_mvt_semantics.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import sys
 
 import mapbox_vector_tile
+import pytest
 from fastapi.testclient import TestClient
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -38,7 +39,7 @@ DIST = ROOT.parent / "server-styling" / "dist"
     "<color-table name='DAY_BRIGHT'><color name='DEPVS' r='1' g='2' b='3'/><color name='DEPDW' r='4' g='5' b='6'/></color-table>"
     "<symbols>"
     "<symbol name='ISODGR51'><bitmap width='1' height='1'><graphics-location x='0' y='0'/></bitmap></symbol>"
-    "<symbol name='DANGER51'><bitmap width='1' height='1'><graphics-location x='1' y='0'/></bitmap></symbol>"
+    "<symbol name='DANGER51'><bitmap width='1' height='1'><graphics-location x='1' y='0'/></bitmap><pivot x='0' y='0'/></symbol>"
     "</symbols>"
     "</root>"
 )
@@ -155,6 +156,16 @@ def test_hazard_icon_prefixed() -> None:
     assert any(
         f["properties"].get("hazardIcon") and f"s52-{f['properties']['hazardIcon']}" in sprite
         for f in hazard_feats
+    )
+
+
+def test_hazard_offsets_present() -> None:
+    feats = _decode(10)
+    hazards = [f for f in feats if f["properties"].get("hazardIcon") == "DANGER51"]
+    if not hazards:
+        pytest.skip("DANGER51 feature missing")
+    assert any(
+        "hazardOffX" in h["properties"] and "hazardOffY" in h["properties"] for h in hazards
     )
 
 

--- a/VDR/chart-tiler/tileserver.py
+++ b/VDR/chart-tiler/tileserver.py
@@ -79,7 +79,7 @@ _symbols = parse_symbols(_root)
 
 @lru_cache(maxsize=32)
 def _get_classifier(sc: float) -> S52PreClassifier:
-    return S52PreClassifier(sc, _day_colors, _symbols)
+    return S52PreClassifier(sc, _day_colors, symbols=_symbols)
 
 
 @lru_cache(maxsize=512)

--- a/VDR/docs/PR_SUMMARY_PHASE4.md
+++ b/VDR/docs/PR_SUMMARY_PHASE4.md
@@ -1,0 +1,25 @@
+# Phase 4 Summary
+
+## What changed
+- Documented CM93/S-57 to Web pipeline with auto-generated coverage section.
+- Added hazard sprite offsets and prefix-safe consumption.
+- CI now validates styles with Node validator and checks docs freshness.
+
+## How to run
+See commands in repository README or run:
+```
+python VDR/server-styling/sync_opencpn_assets.py --lock VDR/server-styling/opencpn-assets.lock --dest VDR/server-styling/dist/assets/s52 --force
+python VDR/server-styling/generate_sprite_json.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml --output VDR/server-styling/dist/sprites/s52-day.json
+python VDR/server-styling/build_style_json.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml --tiles-url "/tiles/cm93/{z}/{x}/{y}?fmt=mvt&sc={sc}" --source-name cm93 --source-layer features --sprite-base "/sprites/s52-day" --sprite-prefix "s52-" --glyphs "/glyphs/{fontstack}/{range}.pbf" --safety-contour 10 --output VDR/server-styling/dist/style.s52.day.json
+npm install --no-save @maplibre/maplibre-gl-style-spec
+node VDR/server-styling/tools/validate_style.mjs VDR/server-styling/dist/style.s52.day.json
+python VDR/server-styling/s52_coverage.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml
+python VDR/server-styling/tools/update_docs_from_coverage.py --docs VDR/docs/s52s57cm93.md --coverage VDR/server-styling/dist/coverage/style_coverage.json --symbols VDR/server-styling/dist/coverage/symbols_seen.txt
+pytest VDR/server-styling/tests -q
+pytest VDR/chart-tiler/tests -q
+```
+
+## Risks & roll-back
+- Offsets rely on symbol metadata; if anchors missing, icons render centered.
+- Docs check only warns; stale coverage blocks can be refreshed via update_docs_from_coverage.py.
+

--- a/VDR/docs/s52s57cm93.md
+++ b/VDR/docs/s52s57cm93.md
@@ -1,0 +1,60 @@
+# CM93/S-57 → Web (S-52 Day) Pipeline
+
+**Design goals:** upstream S-52 assets as-is; vector-first; optional raster; no binaries in PRs; `sc` end-to-end.
+
+## 1. Assets (lock-based)
+- Lock format, required files, manifest, reproducibility, local-src mode.
+
+## 2. Sprite & Style (Day)
+- Sprite: atlas PNG served as-is; JSON generated; **prefix** support.
+- Style: Tier-1 layers; QUAPOS; safety overlay; SOUNDG day tokens; hazard layer (prefix-safe).
+
+## 3. Pre-classification (server-side CSP proxies)
+- DEPARE → `isShallow`, `depthBand`; DEPCNT → `role`; SOUNDG → `isShallow`.
+- UDW hazards → `hazardIcon` (+ now `hazardOffX/hazardOffY`).
+
+## 4. Tile server
+- Endpoints, cache key (`fmt:sc:z/x/y`), headers, metrics.
+
+## 5. CI & Validation
+- Node validator flow; artifacts; tests.
+
+## 6. Configuration & Running Locally
+- Commands, Makefile snippets.
+
+## 7. Coverage (auto-generated)
+<!-- BEGIN:S52_COVERAGE -->
+| metric | value |
+| --- | ---: |
+| total lookups | 231 |
+| covered by style | 5 |
+| missing | 226 |
+
+### Missing OBJL
+- ######
+- $AREAS
+- $CSYMB
+- $LINES
+- $TEXTS
+- ACHARE
+- ACHBRT
+- ACHPNT
+- ADMARE
+- AIRARE
+- ANNOTA
+- ARCSLN
+- ASLXIS
+- BCNCAR
+- BCNISD
+- BCNLAT
+- BCNSAW
+- BCNSPP
+- BCNWTW
+- BERTHS
+
+### Symbols seen
+(none)
+<!-- END:S52_COVERAGE -->
+
+## 8. Known limits & roadmap
+- Night/Dusk later; full pattern fills TBD; raster parity optional.

--- a/VDR/server-styling/.github/workflows/styling.yml
+++ b/VDR/server-styling/.github/workflows/styling.yml
@@ -47,6 +47,14 @@ jobs:
       - name: Coverage summary
         run: |
           python VDR/server-styling/s52_coverage.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml
+      - name: Docs freshness
+        run: |
+          python VDR/server-styling/tools/update_docs_from_coverage.py \
+            --docs VDR/docs/s52s57cm93.md \
+            --coverage VDR/server-styling/dist/coverage/style_coverage.json \
+            --symbols VDR/server-styling/dist/coverage/symbols_seen.txt || true
+          git diff --quiet || {
+            echo "Docs changed. Please commit VDR/docs/s52s57cm93.md"; exit 2; }
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/VDR/server-styling/build_style_json.py
+++ b/VDR/server-styling/build_style_json.py
@@ -221,7 +221,19 @@ def build_layers(
                     ],
                     "icon-allow-overlap": True,
                     "icon-anchor": "center",
-                    "icon-offset": [0, 0],
+                    "icon-offset": [
+                        "array",
+                        "number",
+                        2,
+                        [
+                            "to-number",
+                            ["coalesce", ["get", "hazardOffX"], 0],
+                        ],
+                        [
+                            "to-number",
+                            ["coalesce", ["get", "hazardOffY"], 0],
+                        ],
+                    ],
                     "icon-size": 1.0,
                 },
                 "metadata": {"maplibre:s52": "UDWHAZ-hazardIcon"},

--- a/VDR/server-styling/tests/test_style_soundg.py
+++ b/VDR/server-styling/tests/test_style_soundg.py
@@ -1,0 +1,26 @@
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+import sys
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / 'server-styling'))
+from s52_xml import parse_day_colors
+
+
+def test_soundg_day_tokens():
+    style_path = ROOT / 'server-styling' / 'dist' / 'style.s52.day.json'
+    chartsymbols = ROOT / 'server-styling' / 'dist' / 'assets' / 's52' / 'chartsymbols.xml'
+    if not style_path.exists() or not chartsymbols.exists():
+        pytest.skip('style or chartsymbols missing')
+    style = json.loads(style_path.read_text())
+    root = ET.parse(chartsymbols).getroot()
+    colors = parse_day_colors(root)
+    sndg1 = colors.get('SNDG1')
+    sndg2 = colors.get('SNDG2')
+    assert sndg1 and sndg2
+    soundg = next(lyr for lyr in style['layers'] if lyr['id'] == 'SOUNDG')
+    paint = soundg.get('paint', {})
+    assert sndg1 in paint.get('text-color', [])
+    assert paint.get('text-halo-color') == sndg2

--- a/VDR/server-styling/tools/update_docs_from_coverage.py
+++ b/VDR/server-styling/tools/update_docs_from_coverage.py
@@ -1,0 +1,63 @@
+import argparse
+import json
+from pathlib import Path
+
+BEGIN = "<!-- BEGIN:S52_COVERAGE -->"
+END = "<!-- END:S52_COVERAGE -->"
+
+
+def render(coverage_path: Path, symbols_path: Path, limit: int = 20) -> str:
+    coverage = json.loads(coverage_path.read_text())
+    total = coverage.get("totalLookups", 0)
+    covered = coverage.get("coveredByStyle", 0)
+    missing = coverage.get("missingObjL", [])
+    symbols = symbols_path.read_text().splitlines() if symbols_path.exists() else []
+    missing_block = "\n".join(f"- {m}" for m in missing[:limit]) or "(none)"
+    symbols_block = "\n".join(f"- {s}" for s in sorted(symbols)[:limit]) or "(none)"
+    lines = [
+        "| metric | value |",
+        "| --- | ---: |",
+        f"| total lookups | {total} |",
+        f"| covered by style | {covered} |",
+        f"| missing | {len(missing)} |",
+        "",
+        "### Missing OBJL",
+        missing_block,
+        "",
+        "### Symbols seen",
+        symbols_block,
+    ]
+    return "\n".join(lines)
+
+
+def update_docs(doc_path: Path, block: str) -> bool:
+    text = doc_path.read_text()
+    start = text.find(BEGIN)
+    end = text.find(END)
+    if start == -1 or end == -1 or end < start:
+        raise RuntimeError("Coverage markers not found in docs")
+    before = text[: start + len(BEGIN)]
+    after = text[end:]
+    new_text = before + "\n" + block + "\n" + after
+    if new_text == text:
+        return False
+    doc_path.write_text(new_text)
+    return True
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Update docs with coverage data")
+    p.add_argument("--docs", type=Path, required=True)
+    p.add_argument("--coverage", type=Path, required=True)
+    p.add_argument("--symbols", type=Path, required=True)
+    args = p.parse_args()
+    block = render(args.coverage, args.symbols)
+    updated = update_docs(args.docs, block)
+    if updated:
+        print("Documentation updated")
+    else:
+        print("Documentation already up to date")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document CM93/S-57 to S-52 Day pipeline with auto-generated coverage block
- compute anchor-based hazard offsets and apply them in style generation
- run Node style validator and check docs freshness in CI

## Testing
- `npm install --no-save @maplibre/maplibre-gl-style-spec`
- `node VDR/server-styling/tools/validate_style.mjs VDR/server-styling/dist/style.s52.day.json`
- `python VDR/server-styling/s52_coverage.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml`
- `python VDR/server-styling/tools/update_docs_from_coverage.py --docs VDR/docs/s52s57cm93.md --coverage VDR/server-styling/dist/coverage/style_coverage.json --symbols VDR/server-styling/dist/coverage/symbols_seen.txt`
- `pytest VDR/server-styling/tests -q`
- `pytest VDR/chart-tiler/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689faf2a3184832a9cf160f9561659c4