### PR TITLE
feat: stage local S-52 assets and coverage checks

### DIFF
--- a/VDR/chart-tiler/tests/test_s57_catalogue_ingest.py
+++ b/VDR/chart-tiler/tests/test_s57_catalogue_ingest.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+ASSETS_CSV = ROOT.parent / "server-styling" / "dist" / "assets" / "s52" / "s57objectclasses.csv"
+
+from s52_preclass import S52PreClassifier
+from mvt_builder import encode_mvt
+
+
+def test_s57_catalogue_ingest():
+    if not ASSETS_CSV.exists():
+        pytest.skip("s57objectclasses.csv not staged")
+    classifier = S52PreClassifier(0.0, {})
+    with ASSETS_CSV.open(newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            objl = row.get("Acronym") or row.get("acronym")
+            if not objl:
+                continue
+            props = {"OBJL": objl}
+            props.update(classifier.classify(objl, props))
+            feat = {"geometry": {"type": "Point", "coordinates": [0.0, 0.0]}, "properties": props}
+            data = encode_mvt([feat])
+            assert isinstance(data, (bytes, bytearray)) and data

--- a/VDR/docs/PR_SUMMARY_STAGE_ASSETS_AND_COVERAGE.md
+++ b/VDR/docs/PR_SUMMARY_STAGE_ASSETS_AND_COVERAGE.md
@@ -1,0 +1,14 @@
+# Summary
+- add `stage_local_assets.py` to copy S-52/S-57 assets from `data/s57data`
+- support `--emit-name` in `build_all_styles.py`
+- broaden style coverage checks and doc updater
+- document staging flow and update coverage block
+- add ingest test for all S-57 object classes
+
+# Testing
+- `python VDR/server-styling/tools/stage_local_assets.py --repo-data data/s57data --dest VDR/server-styling/dist/assets/s52 --force`
+- `python VDR/server-styling/tools/build_all_styles.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml --tiles-url "/tiles/cm93/{z}/{x}/{y}?fmt=mvt&safety={safety}&shallow={shallow}&deep={deep}" --source-name cm93 --source-layer features --sprite-base "/sprites/s52-day" --sprite-prefix "s52-" --glyphs "/glyphs/{fontstack}/{range}.pbf"`
+- `node VDR/server-styling/tools/validate_style.mjs VDR/server-styling/dist/style.s52.day.json`
+- `python VDR/server-styling/s52_coverage.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml`
+- `python VDR/server-styling/tools/update_docs_from_coverage.py --docs VDR/docs/s52s57cm93.md --coverage VDR/server-styling/dist/coverage/style_coverage.json --symbols VDR/server-styling/dist/coverage/symbols_seen.txt`
+- `pytest -q VDR/chart-tiler/tests/test_s57_catalogue_ingest.py`

--- a/VDR/docs/s52s57cm93.md
+++ b/VDR/docs/s52s57cm93.md
@@ -23,6 +23,13 @@ python VDR/server-styling/sync_opencpn_assets.py \
   --lock VDR/server-styling/opencpn-assets.lock \
   --dest VDR/server-styling/dist/assets/s52 --force
 ```
+- Local assets from `data/s57data/`:
+
+```
+python VDR/server-styling/tools/stage_local_assets.py \
+  --repo-data data/s57data \
+  --dest VDR/server-styling/dist/assets/s52 --force
+```
 - Build all palettes for development:
 
 ```
@@ -61,12 +68,7 @@ python VDR/server-styling/tools/build_all_styles.py \
 | missing | 221 |
 
 ### Delta
-covered change: +5
-- ACHARE
-- ADMARE
-- BCNCAR
-- BOYCAR
-- SEAARE
+covered change: +0
 
 ### Missing OBJL
 - ######
@@ -89,6 +91,11 @@ covered change: +5
 - BOYINB
 - BOYISD
 - BOYLAT
+- BOYSAW
+- BOYSPP
+- BOYWTW
+- BRIDGE
+- BUAARE
 
 ### Symbols seen
 (none)

--- a/VDR/server-styling/.gitignore
+++ b/VDR/server-styling/.gitignore
@@ -7,3 +7,5 @@ dist/*.rle
 dist/*.RLE
 dist/*.csv
 dist/*.CSV
+dist/coverage/
+dist/style.s52.*.json

--- a/VDR/server-styling/s52_coverage.py
+++ b/VDR/server-styling/s52_coverage.py
@@ -40,14 +40,14 @@ def main() -> None:  # pragma: no cover - CLI helper
 
     # Style coverage -------------------------------------------------------
     base = Path(__file__).resolve().parent
-    style_path = base / "dist" / "style.s52.day.json"
-    coverage_dir = base / "dist" / "coverage"
+    dist_dir = base / "dist"
+    coverage_dir = dist_dir / "coverage"
     current_path = coverage_dir / "style_coverage.json"
     prev_path = coverage_dir / "style_coverage.prev.json"
     tokens: list[str] = []
     layers: list[dict[str, str]] = []
     symbols_seen: set[str] = set()
-    if style_path.exists():
+    for style_path in dist_dir.glob("style.s52.*.json"):
         style = json.loads(style_path.read_text())
         for lyr in style.get("layers", []):
             token = lyr.get("metadata", {}).get("maplibre:s52")

--- a/VDR/server-styling/tools/build_all_styles.py
+++ b/VDR/server-styling/tools/build_all_styles.py
@@ -22,6 +22,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--sprite-prefix", default="")
     p.add_argument("--glyphs", required=True)
     p.add_argument("--safety-contour", type=float, default=0.0)
+    p.add_argument("--emit-name")
     return p.parse_args()
 
 
@@ -50,6 +51,7 @@ def main() -> int:  # pragma: no cover - CLI helper
             str(args.safety_contour),
             "--sprite-prefix",
             args.sprite_prefix,
+            *( ["--emit-name", args.emit_name] if args.emit_name else [] ),
             "--palette",
             pal,
             "--output",

--- a/VDR/server-styling/tools/stage_local_assets.py
+++ b/VDR/server-styling/tools/stage_local_assets.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Stage S-52/S-57 assets from a repo-local data directory."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+from pathlib import Path
+
+ASSETS = [
+    "chartsymbols.xml",
+    "rastersymbols-day.png",
+    "S52RAZDS.RLE",
+    "s57objectclasses.csv",
+    "s57attributes.csv",
+    "attdecode.csv",
+]
+
+
+def _hash_path(path: Path) -> str:
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def stage_assets(repo_data: Path, dest: Path, force: bool) -> dict[str, str]:
+    manifest: dict[str, str] = {}
+    dest.mkdir(parents=True, exist_ok=True)
+    for name in ASSETS:
+        src = repo_data / name
+        if not src.exists():
+            continue
+        dst = dest / name
+        if dst.exists() and not force:
+            if dst.read_bytes() == src.read_bytes():
+                manifest[name] = _hash_path(dst)
+                continue
+        shutil.copy2(src, dst)
+        manifest[name] = _hash_path(dst)
+    if manifest:
+        (dest / "assets.manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True)
+        )
+    return manifest
+
+
+def main() -> int:  # pragma: no cover - CLI helper
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--repo-data", type=Path, required=True)
+    p.add_argument("--dest", type=Path, required=True)
+    p.add_argument("--force", action="store_true")
+    args = p.parse_args()
+    manifest = stage_assets(args.repo_data, args.dest, args.force)
+    print(f"Staged {len(manifest)} assets" if manifest else "No assets staged")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    raise SystemExit(main())

--- a/VDR/server-styling/tools/update_docs_from_coverage.py
+++ b/VDR/server-styling/tools/update_docs_from_coverage.py
@@ -6,7 +6,7 @@ BEGIN = "<!-- BEGIN:S52_COVERAGE -->"
 END = "<!-- END:S52_COVERAGE -->"
 
 
-def render(coverage_path: Path, symbols_path: Path, limit: int = 20) -> str:
+def render(coverage_path: Path, symbols_path: Path, limit: int = 25) -> str:
     coverage = json.loads(coverage_path.read_text())
     total = coverage.get("totalLookups", 0)
     covered = coverage.get("coveredByStyle", 0)


### PR DESCRIPTION
## Summary
- add helper to stage S-52/S-57 assets from repo data and emit manifest
- support emit-name in style build script and expand coverage tooling
- document local asset flow and add ingest test for S-57 catalogue

## Testing
- `python VDR/server-styling/tools/stage_local_assets.py --repo-data data/s57data --dest VDR/server-styling/dist/assets/s52 --force`
- `python VDR/server-styling/tools/build_all_styles.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml --tiles-url "/tiles/cm93/{z}/{x}/{y}?fmt=mvt&safety={safety}&shallow={shallow}&deep={deep}" --source-name cm93 --source-layer features --sprite-base "/sprites/s52-day" --sprite-prefix "s52-" --glyphs "/glyphs/{fontstack}/{range}.pbf"`
- `node VDR/server-styling/tools/validate_style.mjs VDR/server-styling/dist/style.s52.day.json`
- `python VDR/server-styling/s52_coverage.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml`
- `python VDR/server-styling/tools/update_docs_from_coverage.py --docs VDR/docs/s52s57cm93.md --coverage VDR/server-styling/dist/coverage/style_coverage.json --symbols VDR/server-styling/dist/coverage/symbols_seen.txt`
- `pytest -q VDR/chart-tiler/tests/test_s57_catalogue_ingest.py`


------
https://chatgpt.com/codex/tasks/task_e_689fc25988c4832a90f0b6039171287d