### PR TITLE
feat: stage assets locally and template style names

### DIFF
--- a/VDR/docs/PR_SUMMARY_STAGE_ASSETS_AND_COVERAGE.md
+++ b/VDR/docs/PR_SUMMARY_STAGE_ASSETS_AND_COVERAGE.md
@@ -1,14 +1,19 @@
-# Summary
-- add `stage_local_assets.py` to copy S-52/S-57 assets from `data/s57data`
-- support `--emit-name` in `build_all_styles.py`
-- broaden style coverage checks and doc updater
-- document staging flow and update coverage block
-- add ingest test for all S-57 object classes
+Summary
 
-# Testing
-- `python VDR/server-styling/tools/stage_local_assets.py --repo-data data/s57data --dest VDR/server-styling/dist/assets/s52 --force`
-- `python VDR/server-styling/tools/build_all_styles.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml --tiles-url "/tiles/cm93/{z}/{x}/{y}?fmt=mvt&safety={safety}&shallow={shallow}&deep={deep}" --source-name cm93 --source-layer features --sprite-base "/sprites/s52-day" --sprite-prefix "s52-" --glyphs "/glyphs/{fontstack}/{range}.pbf"`
-- `node VDR/server-styling/tools/validate_style.mjs VDR/server-styling/dist/style.s52.day.json`
-- `python VDR/server-styling/s52_coverage.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml`
-- `python VDR/server-styling/tools/update_docs_from_coverage.py --docs VDR/docs/s52s57cm93.md --coverage VDR/server-styling/dist/coverage/style_coverage.json --symbols VDR/server-styling/dist/coverage/symbols_seen.txt`
-- `pytest -q VDR/chart-tiler/tests/test_s57_catalogue_ingest.py`
+Added stage_local_assets.py to copy S-52/S-57 assets from data/s57data/ into dist/assets/s52 and emit a manifest (local, reproducible; no network).
+
+Extended build_all_styles.py with --emit-name; still validates Day/Dusk/Night.
+
+Broadened coverage to scan all generated styles and surfaced deltas; docs now show missing OBJL and delta.
+
+Expanded ignore rules to keep generated binaries and dist artifacts out of Git.
+
+Added a regression test that ingests every S-57 object class and encodes to MVT to ensure safe handling.
+
+Testing
+
+See the commands above; all bullets must pass locally.
+
+Risks & Rollback
+
+Doc-only & tooling changes; rollback by deleting the new helper and reverting touched files. No runtime behavior change apart from improved docs/coverage.

--- a/VDR/server-styling/tools/build_all_styles.py
+++ b/VDR/server-styling/tools/build_all_styles.py
@@ -32,6 +32,7 @@ def main() -> int:  # pragma: no cover - CLI helper
     for pal in palettes:
         out = ROOT / "dist" / f"style.s52.{pal}.json"
         sprite_base = args.sprite_base.replace("day", pal)
+        emit_name = args.emit_name.format(palette=pal) if args.emit_name else None
         cmd = [
             sys.executable,
             str(BUILD),
@@ -51,7 +52,7 @@ def main() -> int:  # pragma: no cover - CLI helper
             str(args.safety_contour),
             "--sprite-prefix",
             args.sprite_prefix,
-            *( ["--emit-name", args.emit_name] if args.emit_name else [] ),
+            *( ["--emit-name", emit_name] if emit_name else [] ),
             "--palette",
             pal,
             "--output",


### PR DESCRIPTION
## Summary
- stage local S-52/S-57 resources with manifest and missing-asset reporting
- allow templated names for multi-palette style builds
- document stage assets and coverage workflow

## Testing
- `python VDR/server-styling/tools/stage_local_assets.py --repo-data data/s57data --dest VDR/server-styling/dist/assets/s52 --force`
- `python VDR/server-styling/tools/build_all_styles.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml --tiles-url "/tiles/cm93/{z}/{x}/{y}?fmt=mvt&safety={safety}&shallow={shallow}&deep={deep}" --source-name cm93 --source-layer features --sprite-base "/sprites/s52-day" --sprite-prefix "s52-" --glyphs "/glyphs/{fontstack}/{range}.pbf" --emit-name "OpenCPN S-52 {palette}"`
- `python VDR/server-styling/s52_coverage.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml`
- `python VDR/server-styling/tools/update_docs_from_coverage.py --docs VDR/docs/s52s57cm93.md --coverage VDR/server-styling/dist/coverage/style_coverage.json --symbols VDR/server-styling/dist/coverage/symbols_seen.txt`
- `pytest -q VDR/chart-tiler/tests/test_s57_catalogue_ingest.py`
- `pytest -q VDR/server-styling/tests` *(fails: Cannot find package '@maplibre/maplibre-gl-style-spec')*
- `pytest -q VDR/chart-tiler/tests`


------
https://chatgpt.com/codex/tasks/task_e_689fc596b29c832a89928571a516cec4