### PR TITLE
Expose named attributes and add label layers

### DIFF
--- a/VDR/chart-tiler/tests/test_named_attributes.py
+++ b/VDR/chart-tiler/tests/test_named_attributes.py
@@ -1,0 +1,22 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+# Stub out heavy GDAL dependency for import
+osgeo = types.ModuleType("osgeo")
+osgeo.gdal = types.ModuleType("gdal")
+osgeo.ogr = types.ModuleType("ogr")
+sys.modules.setdefault("osgeo", osgeo)
+sys.modules.setdefault("osgeo.gdal", osgeo.gdal)
+sys.modules.setdefault("osgeo.ogr", osgeo.ogr)
+
+from convert_charts import _named_attributes
+
+
+def test_named_attributes_contains_objnam():
+    attrs = _named_attributes()
+    assert "OBJNAM" in attrs
+    assert "NOBJNM" in attrs

--- a/VDR/server-styling/build_style_json.py
+++ b/VDR/server-styling/build_style_json.py
@@ -555,6 +555,43 @@ def build_layers(
         )
     )
 
+    if labels:
+        layers.append(
+            (
+                prio("OBJNAM", 90),
+                {
+                    "id": "feature-names",
+                    "type": "symbol",
+                    "source": source,
+                    "source-layer": source_layer,
+                    "filter": ["any", ["has", "OBJNAM"], ["has", "NOBJNM"]],
+                    "layout": {
+                        "text-field": [
+                            "coalesce",
+                            ["get", "OBJNAM"],
+                            ["get", "NOBJNM"],
+                        ],
+                        "text-font": ["Noto Sans Regular"],
+                        "text-size": [
+                            "interpolate",
+                            ["linear"],
+                            ["zoom"],
+                            5,
+                            12,
+                            12,
+                            16,
+                        ],
+                    },
+                    "paint": {
+                        "text-color": get_colour(colors, "CHBLK"),
+                        "text-halo-color": "#ffffff",
+                        "text-halo-width": 1,
+                    },
+                    "metadata": {"maplibre:s52": "OBJNAM-label"},
+                },
+            )
+        )
+
     layers.sort(key=lambda tup: tup[0])
     return [layer for _, layer in layers]
 

--- a/VDR/server-styling/tests/test_named_labels.py
+++ b/VDR/server-styling/tests/test_named_labels.py
@@ -1,0 +1,46 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BUILD = ROOT / 'server-styling' / 'build_style_json.py'
+
+
+def _build_style(tmpdir: Path) -> Path:
+    chartsymbols = tmpdir / 'chartsymbols.xml'
+    chartsymbols.write_text(
+        """
+<root>
+  <color-table name='DAY_BRIGHT'>
+    <color name='CHBLK' r='0' g='0' b='0'/>
+    <color name='LANDA' r='1' g='1' b='1'/>
+  </color-table>
+</root>
+        """.strip()
+    )
+    out = tmpdir / 'style.json'
+    cmd = [
+        sys.executable,
+        str(BUILD),
+        '--chartsymbols', str(chartsymbols),
+        '--tiles-url', 'dummy',
+        '--source-name', 'src',
+        '--source-layer', 'lyr',
+        '--sprite-base', '/sprites',
+        '--glyphs', '/glyphs/{fontstack}/{range}.pbf',
+        '--labels',
+        '--output', str(out),
+    ]
+    subprocess.check_call(cmd)
+    return out
+
+
+def test_feature_name_layer(tmp_path: Path) -> None:
+    out = _build_style(tmp_path)
+    style = json.loads(out.read_text())
+    layer = next((lyr for lyr in style['layers'] if lyr['id'] == 'feature-names'), None)
+    assert layer is not None
+    layout = layer['layout']
+    assert layout['text-field'][0] == 'coalesce'
+    assert layout['text-size'][0] == 'interpolate'


### PR DESCRIPTION
## Summary
- Parse s57attributes.csv to identify OBJNAM/NOBJNM and preserve them in tippecanoe output
- Add MapLibre text layer for named chart objects with zoom-based sizing
- Include unit tests for attribute parsing and style layer generation

## Testing
- `pytest VDR/chart-tiler/tests/test_named_attributes.py VDR/server-styling/tests/test_named_labels.py`

------
https://chatgpt.com/codex/tasks/task_e_68a040daeb90832a8b95bad615438949