### PR TITLE
feat: depict named radio beacons

### DIFF
--- a/VDR/server-styling/build_style_json.py
+++ b/VDR/server-styling/build_style_json.py
@@ -295,11 +295,20 @@ def build_layers(
     )
 
     # Point seamarks -------------------------------------------------------
-    seamarks = ["BCNLAT", "BCNCAR", "BCNISD", "BOYISD", "BOYLAT", "BOYCAR"]
+    seamarks = [
+        "BCNLAT",
+        "BCNCAR",
+        "BCNISD",
+        "BOYISD",
+        "BOYLAT",
+        "BOYCAR",
+        "RTPBCN",
+    ]
     for obj in seamarks:
         sym_name = None
         meta = None
-        for cand in (obj + "01", obj + "1", obj):
+        for suffix in ("01", "02", "1", ""):
+            cand = obj + suffix
             if cand in symbols:
                 sym_name = cand
                 meta = symbols[cand]

--- a/VDR/server-styling/tests/test_radio_beacon_labels.py
+++ b/VDR/server-styling/tests/test_radio_beacon_labels.py
@@ -1,0 +1,56 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BUILD = ROOT / 'server-styling' / 'build_style_json.py'
+
+
+def _build_style(tmpdir: Path) -> Path:
+    chartsymbols = tmpdir / 'chartsymbols.xml'
+    chartsymbols.write_text(
+        """
+<root>
+  <color-table name='DAY_BRIGHT'>
+    <color name='CHBLK' r='0' g='0' b='0'/>
+  </color-table>
+  <symbols>
+    <symbol name='RTPBCN02'>
+      <bitmap width='10' height='10' x='0' y='0'/>
+      <pivot x='5' y='5'/>
+    </symbol>
+  </symbols>
+  <lookups>
+    <lookup name='RTPBCN'/>
+  </lookups>
+</root>
+        """.strip()
+    )
+    out = tmpdir / 'style.json'
+    cmd = [
+        sys.executable,
+        str(BUILD),
+        '--chartsymbols', str(chartsymbols),
+        '--tiles-url', 'dummy',
+        '--source-name', 'src',
+        '--source-layer', 'lyr',
+        '--sprite-base', '/sprites',
+        '--glyphs', '/glyphs/{fontstack}/{range}.pbf',
+        '--labels',
+        '--output', str(out),
+    ]
+    subprocess.check_call(cmd)
+    return out
+
+
+def test_radio_beacon_has_label(tmp_path: Path) -> None:
+    style_path = _build_style(tmp_path)
+    style = json.loads(style_path.read_text())
+    layer = next(lyr for lyr in style['layers'] if lyr['id'] == 'RTPBCN')
+    layout = layer['layout']
+    assert layout['icon-image'][0] == 'concat'
+    # Ensure the symbol was resolved to RTPBCN02
+    assert layout['icon-image'][2][-1] == 'RTPBCN02'
+    # Labels enabled: text-field uses OBJNAM
+    assert layout['text-field'][1] == ['get', 'OBJNAM']


### PR DESCRIPTION
## Summary
- show RTPBCN radio beacons in seamark list with symbol fallback
- cover radio beacons with name labels when `--labels` flag enabled
- add regression test for radio-beacon labelling

## Testing
- `pytest -q VDR/server-styling/tests/test_full_s52_coverage.py` (skipped: chartsymbols missing)
- `pytest -q VDR/server-styling/tests/test_lights_portrayal.py`
- `pytest -q VDR/server-styling/tests/test_depths_and_hazards.py` (skipped: style not built)
- `pytest -q VDR/chart-tiler/tests/test_scamin_mapping.py`
- `pytest -q VDR/chart-tiler/tests/test_cm93_adapter.py` (skipped: CM93 adapter missing)
- `pytest -q VDR/chart-tiler/tests/test_mbtiles_stream.py`
- `pytest -q VDR/server-styling/tests`
- `pytest -q VDR/chart-tiler/tests` (fails: duplicated Prometheus metrics)


------
https://chatgpt.com/codex/tasks/task_e_68a047774608832ab492df1c45ca6ed4