### PR TITLE
Add parsers for S-57 catalogues and attributes

### DIFF
--- a/VDR/server-styling/build_style_json.py
+++ b/VDR/server-styling/build_style_json.py
@@ -8,7 +8,6 @@ required for the vector‑first prototype.  Colours and ordering are derived fro
 from __future__ import annotations
 
 import argparse
-import csv
 import json
 import re
 import sys
@@ -22,6 +21,7 @@ from s52_xml import (
     parse_symbols,
     parse_linestyles,
     parse_patterns,
+    parse_s57_catalogue,
 )
 
 
@@ -41,33 +41,6 @@ def get_colour(colours: Dict[str, str], token: str, fallback: str | None = None)
     if fallback and fallback in colours:
         return colours[fallback]
     return "#ff00ff"  # magenta for missing tokens
-
-
-def parse_s57_catalogue(path: Path) -> Dict[str, Set[str]]:
-    """Parse s57objectclasses.csv returning primitives per OBJL."""
-    catalogue: Dict[str, Set[str]] = {}
-    if not path or not path.exists():
-        return catalogue
-    with path.open(newline="") as fh:
-        reader = csv.DictReader(fh)
-        for row in reader:
-            objl = row.get("Acronym") or row.get("acronym")
-            if not objl:
-                continue
-            prims = row.get("Primitives") or row.get("primitives") or "P"
-            prim_set: Set[str] = set()
-            for prim in prims.split(";"):
-                p = prim.strip().upper()
-                if p.startswith("P"):
-                    prim_set.add("P")
-                elif p.startswith("L"):
-                    prim_set.add("L")
-                elif p.startswith("A"):
-                    prim_set.add("A")
-            if not prim_set:
-                prim_set.add("P")
-            catalogue[objl] = prim_set
-    return catalogue
 
 
 def generate_stub_layers_from_catalog(
@@ -916,4 +889,3 @@ def main() -> None:  # pragma: no cover - CLI wrapper
 
 if __name__ == "__main__":
     main()
-

--- a/VDR/server-styling/s52_coverage.py
+++ b/VDR/server-styling/s52_coverage.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import csv
 import json
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -13,21 +12,8 @@ from s52_xml import (
     parse_linestyles,
     parse_patterns,
     parse_lookups,
+    parse_s57_catalogue,
 )
-
-
-def parse_s57_catalogue(path: Path) -> Dict[str, Set[str]]:
-    catalogue: Dict[str, Set[str]] = {}
-    if not path or not path.exists():
-        return catalogue
-    with path.open(newline="") as fh:
-        reader = csv.DictReader(fh)
-        for row in reader:
-            objl = row.get("Acronym") or row.get("acronym")
-            if not objl:
-                continue
-            catalogue[objl] = set((row.get("Primitives") or row.get("primitives") or "P").split(";"))
-    return catalogue
 
 
 def parse_args() -> argparse.Namespace:

--- a/VDR/server-styling/tests/test_s52_xml.py
+++ b/VDR/server-styling/tests/test_s52_xml.py
@@ -2,10 +2,17 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 import sys
 
+
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / 'server-styling'))
 
-from s52_xml import parse_symbols, parse_linestyles, parse_lookups
+from s52_xml import (
+    parse_symbols,
+    parse_linestyles,
+    parse_lookups,
+    parse_s57_catalogue,
+    parse_s57_attributes,
+)
 import pytest
 
 
@@ -46,3 +53,18 @@ def test_symbol_rotation_flag():
     if not sym or 'rotate' not in sym:
         pytest.skip('LITVES03 rotation flag missing in this chartsymbols.xml')
     assert sym['rotate'] is True
+
+
+def test_s57_catalogue_and_attributes():
+    data_dir = ROOT.parent / 'data' / 's57data'
+    cat_path = data_dir / 's57objectclasses.csv'
+    attr_path = data_dir / 's57attributes.csv'
+    if not cat_path.exists() or not attr_path.exists():
+        pytest.skip('s57 CSV catalogues missing')
+    catalogue = parse_s57_catalogue(cat_path)
+    assert catalogue.get('BCNCAR') == {'P'}
+    assert 'L' in catalogue.get('DEPCNT', set())
+    attrs = parse_s57_attributes(attr_path)
+    for key in ['OBJNAM', 'NOBJNM', 'QUAPOS', 'WATLEV', 'SCAMIN', 'ORIENT']:
+        assert key in attrs
+    assert attrs['OBJNAM']['type'] == 'S'


### PR DESCRIPTION
## Summary
- parse S-57 object class and attribute CSVs in `s52_xml`
- reuse catalogue parser in style generation and coverage scripts
- test S-57 catalogue and attribute parsing

## Testing
- `pre-commit run --files VDR/server-styling/s52_xml.py VDR/server-styling/build_style_json.py VDR/server-styling/s52_coverage.py VDR/server-styling/tests/test_s52_xml.py`
- `pytest VDR/server-styling/tests/test_s52_xml.py`


------
https://chatgpt.com/codex/tasks/task_e_68a04e8370b4832a8a35bf185f7246d0