### PR TITLE
Use dedicated Prometheus registry for tileserver metrics

### DIFF
--- a/VDR/chart-tiler/tests/test_tileserver.py
+++ b/VDR/chart-tiler/tests/test_tileserver.py
@@ -6,6 +6,7 @@ import base64
 import json
 from pathlib import Path
 import sys
+import importlib
 
 from fastapi.testclient import TestClient
 
@@ -92,3 +93,9 @@ def test_metrics_endpoint() -> None:
     assert r.status_code == 200
     assert b"tile_gen_ms" in r.content
 
+
+def test_metrics_endpoint_idempotent_import() -> None:
+    mod = importlib.reload(tileserver)
+    new_client = TestClient(mod.app)
+    r = new_client.get("/metrics")
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- use a private CollectorRegistry for tileserver metrics
- adjust metrics endpoint to export from the private registry
- test idempotent metrics after re-importing tileserver

## Testing
- `pre-commit run --files VDR/chart-tiler/tileserver.py VDR/chart-tiler/tests/test_tileserver.py`
- `pytest VDR/chart-tiler/tests/test_tileserver.py`

------
https://chatgpt.com/codex/tasks/task_e_68a051b11458832aa494001446f2adbe