### PR TITLE
Default to respecting SCAMIN during tile conversion

### DIFF
--- a/VDR/chart-tiler/convert_charts.py
+++ b/VDR/chart-tiler/convert_charts.py
@@ -170,7 +170,7 @@ def s57_to_cog(s57_path: str, output_tif: str) -> None:
 def s57_to_mbtiles(
     s57_path: str,
     output_mbtiles: str,
-    respect_scamin: bool = False,
+    respect_scamin: bool = True,
     scamin_map: Optional[Dict[int, int]] = None,
 ) -> None:
     """Generate vector tiles from an S-57 dataset using tippecanoe.
@@ -285,9 +285,9 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
     parser.add_argument("--password", help="SFTP password")
     parser.add_argument("--remote-dir", default=".", help="Remote directory")
     parser.add_argument(
-        "--respect-scamin",
+        "--no-respect-scamin",
         action="store_true",
-        help="Encode tippecanoe minzoom from SCAMIN",
+        help="Disable SCAMIN to tippecanoe minzoom mapping",
     )
     args = parser.parse_args(argv)
 
@@ -306,7 +306,11 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
     mbtiles = out_dir / f"{stem}.mbtiles"
     cog = out_dir / f"{stem}.tif"
 
-    s57_to_mbtiles(str(s57_path), str(mbtiles), respect_scamin=args.respect_scamin)
+    s57_to_mbtiles(
+        str(s57_path),
+        str(mbtiles),
+        respect_scamin=not args.no_respect_scamin,
+    )
     s57_to_cog(str(s57_path), str(cog))
 
     if args.upload:

--- a/VDR/chart-tiler/tests/test_scamin_mapping.py
+++ b/VDR/chart-tiler/tests/test_scamin_mapping.py
@@ -4,6 +4,7 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import convert_charts
 from convert_charts import scamin_to_zoom, _SCAMIN_ZOOM_MAP  # noqa:E402
 
 
@@ -17,3 +18,30 @@ def test_monotonic_and_clamped() -> None:
     assert values == sorted(values)
     assert scamin_to_zoom(1000) == 16
     assert scamin_to_zoom(100000000) == 0
+
+
+def test_respect_scamin_default(monkeypatch, tmp_path) -> None:
+    calls = {}
+
+    def fake_s57_to_mbtiles(path, mbtiles, respect_scamin=True, scamin_map=None):
+        calls["respect"] = respect_scamin
+
+    def fake_s57_to_cog(*args, **kwargs):
+        pass
+
+    def fake_layers(path):  # pragma: no cover - stub
+        return ["L1"]
+
+    monkeypatch.setattr(convert_charts, "_s57_layers", fake_layers)
+    monkeypatch.setattr(convert_charts, "s57_to_mbtiles", fake_s57_to_mbtiles)
+    monkeypatch.setattr(convert_charts, "s57_to_cog", fake_s57_to_cog)
+
+    chart = tmp_path / "chart.000"
+    chart.write_text("")
+    out_dir = tmp_path / "out"
+
+    convert_charts.main([str(chart), str(out_dir)])
+    assert calls["respect"] is True
+
+    convert_charts.main([str(chart), str(out_dir / "o2"), "--no-respect-scamin"])
+    assert calls["respect"] is False

--- a/VDR/docs/PR_SUMMARY_PHASE12.md
+++ b/VDR/docs/PR_SUMMARY_PHASE12.md
@@ -1,0 +1,8 @@
+**Summary**
+
+- Default to respecting SCAMIN when generating vector tiles, deriving `tippecanoe.minzoom` from the `SCAMIN` attribute. Users can opt out via `--no-respect-scamin`.
+
+**Testing**
+
+- `pytest -q VDR/chart-tiler/tests/test_scamin_mapping.py`
+- `pytest -q VDR/chart-tiler/tests`


### PR DESCRIPTION
## Summary
- respect SCAMIN by default when converting S-57 charts to MBTiles
- allow opting out via new `--no-respect-scamin` flag
- document Phase 12 summary

## Testing
- `pytest -q VDR/chart-tiler/tests/test_scamin_mapping.py`
- `pytest -q VDR/chart-tiler/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a0547752ac832ab435ce3fce5349db