### PR TITLE
feat: geotiff registry and base map switching

### DIFF
--- a/VDR/.gitignore
+++ b/VDR/.gitignore
@@ -1,5 +1,6 @@
 chart-tiler/charts.sqlite
 chart-tiler/*.sqlite
+chart-tiler/data/geotiff/
 chart-tiler/tests/*.png
 chart-tiler/tests/*.mbtiles
 chart-tiler/tests/*.tif

--- a/VDR/chart-tiler/Makefile
+++ b/VDR/chart-tiler/Makefile
@@ -1,0 +1,6 @@
+.PHONY: geotiff-cog
+
+# Convert a GeoTIFF to a Cloud Optimized GeoTIFF.
+# Usage: make geotiff-cog SRC=path/to/file.tif
+geotiff-cog:
+	python tools/convert_geotiff.py $(SRC)

--- a/VDR/chart-tiler/mapproxy.yaml
+++ b/VDR/chart-tiler/mapproxy.yaml
@@ -1,0 +1,12 @@
+services:
+  demo: {}
+  tms:
+    use_grid_names: true
+sources:
+  geotiff:
+    type: tile
+    url: http://localhost/titiler/tiles/%(chart_id)s/%(z)s/%(x)s/%(y)s.png
+caches:
+  geotiff_cache:
+    sources: [geotiff]
+    grids: [GLOBAL_WEBMERCATOR]

--- a/VDR/chart-tiler/registry.py
+++ b/VDR/chart-tiler/registry.py
@@ -1,0 +1,175 @@
+"""Light‑weight chart registry with caching.
+
+The real project uses a richer catalogue; for tests we only implement the
+features required by the API endpoints.  Records are persisted to a small
+SQLite database on disk so the registry can be shared between processes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+DB_PATH = Path(__file__).with_name("registry.sqlite")
+TTL_SEC = 300
+
+
+@dataclass
+class ChartRecord:
+    id: str
+    kind: str
+    name: str
+    bbox: List[float]
+    minzoom: int
+    maxzoom: int
+    updatedAt: float
+    path: Optional[str] = None
+    url: Optional[str] = None
+    tags: List[str] | None = None
+
+
+class Registry:
+    def __init__(self, db_path: Path = DB_PATH):
+        self.db_path = db_path
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._init_db()
+        self._cache_ts = 0.0
+        self._cache: List[ChartRecord] = []
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS charts (
+                id TEXT PRIMARY KEY,
+                kind TEXT,
+                name TEXT,
+                bbox TEXT,
+                minzoom INTEGER,
+                maxzoom INTEGER,
+                updated_at REAL,
+                path TEXT,
+                url TEXT,
+                tags TEXT
+            )
+            """
+        )
+        self.conn.commit()
+
+    # -- scanning -----------------------------------------------------------------
+    def scan(self, paths: Iterable[Path]) -> None:
+        """Scan provided directories for chart artefacts."""
+        cur = self.conn.cursor()
+        now = time.time()
+        for p in paths:
+            if not Path(p).exists():
+                continue
+            for mb in p.rglob("*.mbtiles"):
+                rid = mb.stem
+                # read bounds/minzoom/maxzoom from metadata table if available
+                try:
+                    mconn = sqlite3.connect(mb)
+                    mcur = mconn.cursor()
+                    meta = dict(mcur.execute("SELECT name,value FROM metadata").fetchall())
+                    bbox = list(map(float, meta.get("bounds", "0,0,0,0").split(",")))
+                    minzoom = int(meta.get("minzoom", 0))
+                    maxzoom = int(meta.get("maxzoom", 0))
+                    name = meta.get("name", rid)
+                finally:
+                    mconn.close()
+                cur.execute(
+                    "REPLACE INTO charts (id,kind,name,bbox,minzoom,maxzoom,updated_at,path) VALUES (?,?,?,?,?,?,?,?)",
+                    (rid, "enc", name, json.dumps(bbox), minzoom, maxzoom, now, str(mb)),
+                )
+            for cog in p.rglob("*.cog.json"):
+                rid = cog.stem.replace(".cog", "")
+                info = json.loads(cog.read_text())
+                bbox = info.get("bbox", [0, 0, 0, 0])
+                minzoom = 0
+                maxzoom = 0
+                cur.execute(
+                    "REPLACE INTO charts (id,kind,name,bbox,minzoom,maxzoom,updated_at,path) VALUES (?,?,?,?,?,?,?,?)",
+                    (
+                        rid,
+                        "geotiff",
+                        rid,
+                        json.dumps(bbox),
+                        minzoom,
+                        maxzoom,
+                        now,
+                        str(cog.with_suffix(".tif")),
+                    ),
+                )
+        if bool(int(os.environ.get("OSM_USE_COMMUNITY", "1"))):
+            cur.execute(
+                "REPLACE INTO charts (id,kind,name,bbox,minzoom,maxzoom,updated_at,url) VALUES (?,?,?,?,?,?,?,?)",
+                (
+                    "osm",
+                    "osm",
+                    "OpenStreetMap",
+                    json.dumps([-180, -90, 180, 90]),
+                    0,
+                    19,
+                    now,
+                    "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+                ),
+            )
+        self.conn.commit()
+        self._cache_ts = 0.0  # invalidate cache
+
+    # -- queries ------------------------------------------------------------------
+    def _refresh_cache(self) -> None:
+        if time.time() - self._cache_ts < TTL_SEC:
+            return
+        cur = self.conn.cursor()
+        rows = cur.execute(
+            "SELECT id,kind,name,bbox,minzoom,maxzoom,updated_at,path,url,tags FROM charts"
+        ).fetchall()
+        self._cache = [
+            ChartRecord(
+                id=row[0],
+                kind=row[1],
+                name=row[2],
+                bbox=json.loads(row[3]),
+                minzoom=row[4],
+                maxzoom=row[5],
+                updatedAt=row[6],
+                path=row[7],
+                url=row[8],
+                tags=json.loads(row[9]) if row[9] else None,
+            )
+            for row in rows
+        ]
+        self._cache_ts = time.time()
+
+    def list(self, kind: Optional[str] = None, q: Optional[str] = None, page: int = 1, pageSize: int = 50) -> List[ChartRecord]:
+        self._refresh_cache()
+        items = self._cache
+        if kind:
+            items = [i for i in items if i.kind == kind]
+        if q:
+            items = [i for i in items if q.lower() in i.name.lower()]
+        start = (page - 1) * pageSize
+        end = start + pageSize
+        return items[start:end]
+
+    def get(self, id: str) -> Optional[ChartRecord]:
+        self._refresh_cache()
+        for item in self._cache:
+            if item.id == id:
+                return item
+        return None
+
+
+_registry: Registry | None = None
+
+
+def get_registry() -> Registry:
+    global _registry
+    if not _registry:
+        _registry = Registry()
+    return _registry

--- a/VDR/chart-tiler/tests/test_charts_api.py
+++ b/VDR/chart-tiler/tests/test_charts_api.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import json
+from fastapi.testclient import TestClient
+
+from tileserver import app, reg
+
+
+def test_charts_list_and_filter(tmp_path, monkeypatch):
+    # prepare registry with fake records
+    from registry import Registry
+    r = Registry(tmp_path / "r.sqlite")
+    r.scan([tmp_path])
+    monkeypatch.setattr("tileserver.reg", r)
+    client = TestClient(app)
+    resp = client.get("/charts")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    # default includes osm
+    assert any(d["id"] == "osm" for d in data)
+    resp = client.get("/charts", params={"kind": "osm"})
+    assert resp.json()[0]["id"] == "osm"
+    # detail
+    resp = client.get("/charts/osm")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "osm"

--- a/VDR/chart-tiler/tests/test_convert_geotiff.py
+++ b/VDR/chart-tiler/tests/test_convert_geotiff.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import json
+from pathlib import Path
+from unittest import mock
+
+from tools import convert_geotiff
+
+
+def fake_run(cmd, check, capture_output=False, text=False):
+    class P:
+        def __init__(self):
+            self.stdout = (
+                "Upper Left  (-180.0, 90.0)\n"
+                "Lower Right (180.0,-90.0)\n"
+                "EPSG:4326\n"
+                "Pixel Size = (0.5,-0.5)\n"
+                "Overviews: 256x256 128x128 64x64 32x32\n"
+            )
+    if cmd[0] == "gdal_translate":
+        # create output file to satisfy checksum
+        Path(cmd[-1]).write_bytes(b"cog")
+        return P()
+    return P()
+
+
+def test_convert(tmp_path):
+    tif = tmp_path / "in.tif"
+    tif.write_bytes(b"dummy")
+    convert_geotiff.DATA_DIR = tmp_path
+    convert_geotiff.DATA_DIR.mkdir(exist_ok=True)
+    with mock.patch("subprocess.run", side_effect=fake_run) as run:
+        out = convert_geotiff.convert(tif)
+        assert out.exists()
+        sidecar = out.with_suffix(".json")
+        info = json.loads(sidecar.read_text())
+        assert info["bbox"] == [-180.0, -90.0, 180.0, 90.0]
+        assert info["epsg"] == 4326
+        assert len(info["overviews"]) >= 4
+        # second run uses sidecar and does not call gdal again
+        out2 = convert_geotiff.convert(tif)
+        assert out2 == out
+        assert run.call_count == 2

--- a/VDR/chart-tiler/tests/test_registry_scan.py
+++ b/VDR/chart-tiler/tests/test_registry_scan.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import json
+import sqlite3
+from pathlib import Path
+
+from registry import Registry
+
+
+def make_mbtiles(path: Path, name="chart"):
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE metadata (name TEXT, value TEXT)")
+    cur.executemany(
+        "INSERT INTO metadata VALUES (?,?)",
+        [
+            ("name", name),
+            ("bounds", "0,0,1,1"),
+            ("minzoom", "0"),
+            ("maxzoom", "5"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_scan(tmp_path):
+    mb = tmp_path / "a.mbtiles"
+    make_mbtiles(mb, name="Sample")
+    cog = tmp_path / "b.cog.tif"
+    cog.write_bytes(b"cog")
+    cog_json = tmp_path / "b.cog.json"
+    cog_json.write_text(json.dumps({"bbox": [0, 0, 2, 2]}))
+    r = Registry(tmp_path / "reg.sqlite")
+    r.scan([tmp_path])
+    # should include mbtiles, cog and osm
+    all_items = r.list()
+    kinds = {c.kind for c in all_items}
+    assert {"enc", "geotiff", "osm"} <= kinds
+    # filter by kind
+    geos = r.list(kind="geotiff")
+    assert geos and geos[0].id == "b"
+    # search
+    mbtiles = r.list(q="Sample")
+    assert mbtiles and mbtiles[0].id == "a"

--- a/VDR/chart-tiler/tests/test_tiles_geotiff.py
+++ b/VDR/chart-tiler/tests/test_tiles_geotiff.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from fastapi.testclient import TestClient
+
+from tileserver import app, _geo_hits
+
+
+def test_geotiff_tiles_cache():
+    client = TestClient(app)
+    r1 = client.get("/tiles/geotiff/test/0/0/0.png")
+    assert r1.status_code == 200
+    assert r1.headers["X-Tile-Cache"] == "miss"
+    hits_before = _geo_hits._value.get() if hasattr(_geo_hits, "_value") else _geo_hits._value
+    r2 = client.get("/tiles/geotiff/test/0/0/0.png")
+    assert r2.headers["X-Tile-Cache"] == "hit"
+    hits_after = _geo_hits._value.get() if hasattr(_geo_hits, "_value") else _geo_hits._value
+    assert hits_after == hits_before + 1

--- a/VDR/chart-tiler/tools/convert_geotiff.py
+++ b/VDR/chart-tiler/tools/convert_geotiff.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Convert a GeoTIFF into a Cloud Optimized GeoTIFF (COG).
+
+The script is a light wrapper around ``gdal_translate`` and ``gdalinfo``.  It
+creates the COG with internal overviews and writes a small JSON sidecar with
+basic spatial metadata.  Re‑running the command is idempotent – if the input
+file checksum matches the one recorded in the sidecar the conversion is
+skipped.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data" / "geotiff"
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+GDAL_TRANSLATE_OPTS = [
+    "-of", "COG",
+    "-co", "COMPRESS=LZW",
+    "-co", "BIGTIFF=IF_NEEDED",
+    "-co", "BLOCKSIZE=512",
+    "-co", "RESAMPLING=AVERAGE",
+    "-co", "OVERVIEWS=IGNORE_EXISTING",
+]
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(8192)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def parse_gdalinfo(text: str) -> Dict[str, Any]:
+    """Very small parser for the bits of gdalinfo we care about."""
+    bbox: List[float] = []
+    epsg = None
+    res: List[float] = []
+    overviews: List[int] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("Upper Left"):
+            parts = line.split("(")[1].split(")")[0].split(",")
+            ulx, uly = map(float, parts)
+            bbox = [ulx, 0, 0, uly]
+        elif line.startswith("Lower Right") and bbox:
+            parts = line.split("(")[1].split(")")[0].split(",")
+            lrx, lry = map(float, parts)
+            bbox[2], bbox[1] = lrx, lry
+        elif line.startswith("EPSG"):
+            try:
+                epsg = int(line.split(":")[1])
+            except Exception:
+                pass
+        elif "Pixel Size" in line:
+            parts = line.split("(")[1].split(")")[0].split(",")
+            res = [float(parts[0]), float(parts[1])]
+        elif line.startswith("Overviews"):
+            nums = [int(p.split("x")[0]) for p in line.split(" ") if "x" in p]
+            overviews = nums
+    return {"bbox": bbox, "epsg": epsg, "resolution": res, "overviews": overviews}
+
+
+def convert(path: Path) -> Path:
+    """Convert ``path`` to a COG if needed and return output path."""
+    assert path.exists(), f"{path} missing"
+    out = DATA_DIR / f"{path.stem}.cog.tif"
+    sidecar = out.with_suffix(".json")
+    digest = sha256(path)
+    if sidecar.exists():
+        try:
+            info = json.loads(sidecar.read_text())
+            if info.get("checksum") == digest and out.exists():
+                return out
+        except Exception:
+            pass
+    # Build COG
+    cmd = ["gdal_translate", *GDAL_TRANSLATE_OPTS, str(path), str(out)]
+    subprocess.run(cmd, check=True, capture_output=True)
+    # Gather metadata
+    info_cmd = ["gdalinfo", str(out)]
+    proc = subprocess.run(info_cmd, check=True, capture_output=True, text=True)
+    meta = parse_gdalinfo(proc.stdout)
+    meta["checksum"] = digest
+    sidecar.write_text(json.dumps(meta, indent=2))
+    return out
+
+
+def main(argv: List[str] | None = None) -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("tiff", type=Path, help="Input GeoTIFF")
+    args = ap.parse_args(argv)
+    convert(args.tiff)
+
+
+if __name__ == "__main__":
+    main()

--- a/VDR/docs/PR_SUMMARY_PHASE_1_3_1_TO_1_4_1.md
+++ b/VDR/docs/PR_SUMMARY_PHASE_1_3_1_TO_1_4_1.md
@@ -1,0 +1,15 @@
+# Phase 1.3/1.4 Addenda Summary
+
+This patch series introduces the GeoTIFF conversion tool, a cached chart
+registry with new FastAPI endpoints, a placeholder GeoTIFF tile service and a
+MapLibre AppMap capable of switching between OSM, GeoTIFF and ENC bases.  It also
+documents CM93/S‑57 readiness and provides operator notes for importing charts
+and refreshing the registry.
+
+## Testing
+
+- `pytest VDR/chart-tiler/tests/test_convert_geotiff.py`
+- `pytest VDR/chart-tiler/tests/test_registry_scan.py`
+- `pytest VDR/chart-tiler/tests/test_tiles_geotiff.py`
+- `pytest VDR/chart-tiler/tests/test_charts_api.py`
+- `npm test --prefix VDR/web-client`

--- a/VDR/docs/cm93_s57_phase2.md
+++ b/VDR/docs/cm93_s57_phase2.md
@@ -1,0 +1,24 @@
+# CM93 / S-57 Phase‑2 Readiness
+
+The current architecture defers ingesting CM93 and S‑57 data until a later
+phase.  Hooks are nevertheless in place so the data can be enabled without
+structural changes:
+
+* `OPENCN_CM93_CLI` – optional environment variable that points to a CM93
+  conversion tool.  When unset the system skips CM93 processing.
+* SCAMIN → `minzoom` mapping is implemented in the tile server behind a flag so
+  ENC data can downsample gracefully.
+* Styling uses stable layer identifiers and the `metadata.maplibre:s52` token so
+  additional symbol sets can be introduced without breaking existing layers.
+
+### OBJL → MVT design
+
+Future CM93/S‑57 import will map object classes (OBJL) into Mapbox Vector Tile
+source layers named `features`.  Pre‑classification fields already supported in
+Phase 1 include `Lights`, `Navaids`, `Hazards` and `Depths`.
+
+### Test plan (for when data arrives)
+
+1. Convert sample CM93/S‑57 datasets with the external CLI.
+2. Import into the registry and verify `/charts` includes the new records.
+3. Render tiles and confirm SCAMIN filtering behaves as expected.

--- a/VDR/docs/geotiff_cog.md
+++ b/VDR/docs/geotiff_cog.md
@@ -1,0 +1,14 @@
+# GeoTIFF → Cloud Optimized GeoTIFF
+
+Use `tools/convert_geotiff.py` to normalise incoming GeoTIFF charts into a
+Cloud Optimized GeoTIFF (COG).  The script wraps `gdal_translate` with the
+recommended options and writes a sidecar JSON file with spatial metadata.
+
+```bash
+cd VDR/chart-tiler
+make geotiff-cog SRC=/path/to/input.tif
+```
+
+Output files are placed under `chart-tiler/data/geotiff` (ignored by git) and
+are safe to regenerate – runs are skipped when the checksum matches the existing
+sidecar.

--- a/VDR/docs/operator_runbook.md
+++ b/VDR/docs/operator_runbook.md
@@ -1,0 +1,20 @@
+# Operator Runbook
+
+## Refresh the Registry
+
+```bash
+cd VDR/chart-tiler
+python -c "from registry import get_registry; get_registry().scan([Path('data')])"  # refresh
+```
+
+## Import a GeoTIFF
+
+```bash
+cd VDR/chart-tiler
+make geotiff-cog SRC=/charts/foo.tif
+```
+
+## Select Base Map
+
+The web client reads `/charts` to populate the base picker.  Toggle between
+`osm`, `geotiff` and `enc` bases at runtime without reloading the page.

--- a/VDR/docs/registry.md
+++ b/VDR/docs/registry.md
@@ -1,0 +1,15 @@
+# Chart Registry
+
+`registry.py` maintains a small SQLite database listing available chart sources
+(MBTiles, GeoTIFF and optional OSM base layers).  The registry is refreshed on
+server start and cached in memory for five minutes.
+
+FastAPI endpoints expose the data:
+
+- `GET /charts` – list records with optional `kind`, `q`, `page` and
+  `pageSize` filters.
+- `GET /charts/{id}` – chart detail.
+- `GET /charts/{id}/thumbnail` – optional thumbnail if present on disk.
+
+Importers inspect `.mbtiles` and `.cog.json` files from the data directory.
+Virtual OSM entries are added when `OSM_USE_COMMUNITY=true` (default).

--- a/VDR/web-client/package.json
+++ b/VDR/web-client/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "deck.gl": "^8.9.0",
+    "maplibre-gl": "^2.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "maplibre-gl": "^2.4.0",
-    "deck.gl": "^8.9.0",
+    "ts-node": "^10.9.2",
     "zustand": "^4.5.2"
   },
   "scripts": {
-    "test": "node -r ts-node/register src/components/AppMap.test.ts"
+    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS=\"{\\\"jsx\\\":\\\"react\\\",\\\"module\\\":\\\"commonjs\\\"}\" node -r ts-node/register src/components/AppMap.test.ts && TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS=\"{\\\"jsx\\\":\\\"react\\\",\\\"module\\\":\\\"commonjs\\\"}\" node -r ts-node/register src/components/test_appmap_bases.spec.ts"
   }
 }

--- a/VDR/web-client/src/components/test_appmap_bases.spec.ts
+++ b/VDR/web-client/src/components/test_appmap_bases.spec.ts
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import { createMapAPI } from './AppMap';
+
+function mockMap() {
+  return {
+    style: { sources: {} as any },
+    setStyle(s: any) { this.style = s; },
+    getStyle() { return this.style; },
+    layout: [] as any[],
+    setLayoutProperty(id: string, prop: string, value: string) {
+      this.layout.push([id, prop, value]);
+    },
+  } as any;
+}
+
+const map = mockMap();
+const api = createMapAPI(map);
+api.setBase('osm');
+assert.ok(map.style.sources.base.tiles[0].includes('openstreetmap'));
+api.setBase('geotiff', 'g1');
+assert.ok(map.style.sources.base.tiles[0].includes('/tiles/geotiff/g1'));
+console.log('bases ok');


### PR DESCRIPTION
## Summary
- add GeoTIFF→COG converter and registry-backed chart metadata API
- serve GeoTIFF tiles with cached FastAPI endpoints
- enable AppMap base switching between OSM, GeoTIFF and ENC

## Testing
- `pytest VDR/chart-tiler/tests/test_convert_geotiff.py VDR/chart-tiler/tests/test_registry_scan.py VDR/chart-tiler/tests/test_tiles_geotiff.py VDR/chart-tiler/tests/test_charts_api.py`
- `npm test --prefix VDR/web-client`


------
https://chatgpt.com/codex/tasks/task_e_68a0614d2104832a95701f1eecbcf709