### PR TITLE
docs: expand Phase 1.3/1.4 summary

### DIFF
--- a/VDR/docs/PR_SUMMARY_PHASE_1_3_1_TO_1_4_1.md
+++ b/VDR/docs/PR_SUMMARY_PHASE_1_3_1_TO_1_4_1.md
@@ -2,9 +2,27 @@
 
 This patch series introduces the GeoTIFF conversion tool, a cached chart
 registry with new FastAPI endpoints, a placeholder GeoTIFF tile service and a
-MapLibre AppMap capable of switching between OSM, GeoTIFF and ENC bases.  It also
+MapLibre AppMap capable of switching between OSM, GeoTIFF and ENC bases. It also
 documents CM93/S‑57 readiness and provides operator notes for importing charts
 and refreshing the registry.
+
+## What / Why / How
+
+- **What** – adds a GDAL‐based GeoTIFF→COG converter, a SQLite chart registry, a
+  cached GeoTIFF tile proxy and MapLibre client wiring for base/theme/mariner
+  switches. Documentation covers operator workflows and CM93/S‑57 readiness.
+- **Why** – enables incremental ingestion of raster charts while preserving the
+  existing S‑52 portrayal and offers a simple API surface for clients.
+- **How** – new tooling under `chart-tiler/tools`, registry helpers and
+  `/charts` endpoints in the FastAPI server, a MapProxy‑style `tiles/geotiff/*`
+  facade with Prometheus metrics, an AppMap component exposing switching APIs and
+  accompanying docs.
+
+## Risks & Rollback
+
+- Minimal risk: tile proxy is a stub and only serves cached 1×1 tiles.
+- Registry scan is idempotent but operators should back up the SQLite database.
+- Rollback by restoring previous images and removing generated COG/SQLite files.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- document GeoTIFF converter, registry, tile proxy and AppMap base/theme/mariner switches
- add explicit what/why/how and risks & rollback sections for Phase 1.3/1.4

## Testing
- `pytest VDR/chart-tiler/tests/test_convert_geotiff.py -q`
- `pytest VDR/chart-tiler/tests/test_registry_scan.py -q`
- `pytest VDR/chart-tiler/tests/test_tiles_geotiff.py -q`
- `pytest VDR/chart-tiler/tests/test_charts_api.py -q`
- `npm test --prefix VDR/web-client`


------
https://chatgpt.com/codex/tasks/task_e_68a066ef00cc832a8b922ae2a77082d3