### PR TITLE
refine geotiff tooling and tile cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ tags
 
 # Ignore Build Dependency files
 *build-deps*
+
+# Chart tiler generated artefacts
+VDR/chart-tiler/data/**/*.cog.tif
+VDR/chart-tiler/data/**/*.cog.json
+VDR/chart-tiler/registry.sqlite

--- a/VDR/web-client/src/components/AppMap.tsx
+++ b/VDR/web-client/src/components/AppMap.tsx
@@ -28,11 +28,21 @@ export function createMapAPI(map: any) {
     setBase(base: 'osm' | 'geotiff' | 'enc', chartId?: string) {
       const style = map.getStyle ? map.getStyle() : { sources: {} };
       if (base === 'osm') {
-        style.sources.base = {
-          type: 'raster',
-          tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
-          tileSize: 256,
-        };
+        if (process.env.OSM_USE_COMMUNITY === '0') {
+          delete style.sources.base;
+        } else {
+          style.sources.base = {
+            type: 'raster',
+            tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+            tileSize: 256,
+          };
+          style.transformRequest = (url: string) => {
+            if (url.includes('openstreetmap')) {
+              return { url, headers: { 'User-Agent': 'opencpn-chart-tiler' } };
+            }
+            return { url } as any;
+          };
+        }
       } else if (base === 'geotiff' && chartId) {
         style.sources.base = {
           type: 'raster',


### PR DESCRIPTION
## Summary
- embed output path and sha256 in COG sidecar and reuse on subsequent runs
- make Prometheus metrics idempotent, add /healthz, and LRU cache for GeoTIFF tiles with cache headers
- gate OSM base layer and set custom User-Agent; ignore generated chart artefacts

## Testing
- `pytest -q VDR/chart-tiler/tests/test_convert_geotiff.py VDR/chart-tiler/tests/test_registry_scan.py VDR/chart-tiler/tests/test_tiles_geotiff.py VDR/chart-tiler/tests/test_charts_api.py`
- `npm test --prefix VDR/web-client`


------
https://chatgpt.com/codex/tasks/task_e_68a06ccbbda0832aae28ea7c231d0080