### PR TITLE
feat: add ENC MBTiles pipeline and frontend support

### DIFF
--- a/VDR/chart-tiler/convert_charts.py
+++ b/VDR/chart-tiler/convert_charts.py
@@ -172,6 +172,8 @@ def s57_to_mbtiles(
     output_mbtiles: str,
     respect_scamin: bool = True,
     scamin_map: Optional[Dict[int, int]] = None,
+    minzoom: int = 5,
+    maxzoom: int = 14,
 ) -> None:
     """Generate vector tiles from an S-57 dataset using tippecanoe.
 
@@ -214,13 +216,36 @@ def s57_to_mbtiles(
             "tippecanoe",
             "-o",
             output_mbtiles,
-            "-zg",
+            f"--minimum-zoom={minzoom}",
+            f"--maximum-zoom={maxzoom}",
             "--drop-densest-as-needed",
         ]
         for attr in _named_attributes() + ["SCAMIN"]:
             tippecanoe_cmd.extend(["--include", attr])
         tippecanoe_cmd.append(str(geojson))
         subprocess.check_call(tippecanoe_cmd)
+
+
+def encode_s57_to_mbtiles(
+    input_000: str,
+    output_mbtiles: str,
+    respect_scamin: bool = True,
+    minzoom: int = 5,
+    maxzoom: int = 14,
+) -> None:
+    """Public helper used by the operator runbook and tests.
+
+    The function simply forwards to :func:`s57_to_mbtiles` while exposing only
+    the knobs required for the phase‑12 tasks.
+    """
+
+    s57_to_mbtiles(
+        input_000,
+        output_mbtiles,
+        respect_scamin=respect_scamin,
+        minzoom=minzoom,
+        maxzoom=maxzoom,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/VDR/chart-tiler/datasource_mbtiles.py
+++ b/VDR/chart-tiler/datasource_mbtiles.py
@@ -1,3 +1,6 @@
+"""Tiny helper around MBTiles used for tests and the dev tile server."""
+
+import os
 import sqlite3
 from functools import lru_cache
 from typing import Optional, Dict
@@ -6,24 +9,40 @@ from typing import Optional, Dict
 class MBTilesDataSource:
     """Lightweight reader for MBTiles storing Mapbox Vector Tiles.
 
-    The class intentionally keeps the interface tiny: ``get_tile`` returns the
+    The interface intentionally stays very small: :meth:`get_tile` returns the
     raw tile bytes for ``(z, x, y)`` if present.  Metadata from the ``metadata``
-    table is exposed via :meth:`metadata` for informational endpoints.
+    table is exposed via :meth:`metadata` for informational endpoints.  A tiny
+    in‑process LRU cache keeps recently used tiles in memory; the cache size can
+    be tuned via the ``MBTILES_CACHE_SIZE`` environment variable.
     """
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, cache_size: int | None = None) -> None:
         self.path = path
         # ``check_same_thread=False`` allows usage from FastAPI threads.
         self._conn = sqlite3.connect(path, check_same_thread=False)
 
+        size = cache_size or int(os.environ.get("MBTILES_CACHE_SIZE", "1024"))
+
+        # lru_cache needs to wrap a function defined at runtime so we create an
+        # instance specific accessor which forwards to the real implementation.
+        self._cached_get = lru_cache(maxsize=size)(self._get_tile_uncached)
+
+    # -- metadata ---------------------------------------------------------
     def metadata(self) -> Dict[str, str]:
         cur = self._conn.execute("SELECT name, value FROM metadata")
         return {name: value for name, value in cur.fetchall()}
 
-    @lru_cache(maxsize=1024)
-    def get_tile(self, z: int, x: int, y: int) -> Optional[bytes]:
-        """Return raw tile bytes for ``z/x/y`` or ``None`` if missing."""
+    def summary(self) -> Dict[str, object]:
+        meta = self.metadata()
+        return {
+            "name": meta.get("name"),
+            "bounds": meta.get("bounds"),
+            "minzoom": int(meta.get("minzoom", 0)),
+            "maxzoom": int(meta.get("maxzoom", 0)),
+        }
 
+    # -- tiles ------------------------------------------------------------
+    def _get_tile_uncached(self, z: int, x: int, y: int) -> Optional[bytes]:
         tms_y = (2 ** z - 1) - y  # MBTiles stores TMS scheme
         cur = self._conn.execute(
             "SELECT tile_data FROM tiles WHERE zoom_level=? AND tile_column=? AND tile_row=?",
@@ -31,3 +50,8 @@ class MBTilesDataSource:
         )
         row = cur.fetchone()
         return row[0] if row else None
+
+    def get_tile(self, z: int, x: int, y: int) -> Optional[bytes]:
+        """Return raw tile bytes for ``z/x/y`` or ``None`` if missing."""
+
+        return self._cached_get(z, x, y)

--- a/VDR/chart-tiler/s52_preclass.py
+++ b/VDR/chart-tiler/s52_preclass.py
@@ -37,6 +37,10 @@ class S52PreClassifier:
     def classify(self, objl: str, props: Dict[str, Any]) -> Dict[str, Any]:
         """Return style helper attributes based on object and properties."""
         result: Dict[str, Any] = {}
+
+        scamin = props.get("SCAMIN")
+        if isinstance(scamin, (int, float)):
+            result["scamin"] = scamin
         try:
             if float(props.get("QUAPOS", 0)) >= 2:
                 result["isLowAcc"] = True

--- a/VDR/chart-tiler/tests/test_mbtiles_stream.py
+++ b/VDR/chart-tiler/tests/test_mbtiles_stream.py
@@ -48,6 +48,7 @@ def test_mbtiles_stream(tmp_path, monkeypatch):
     assert spec.loader is not None
     spec.loader.exec_module(tileserver)
     client = TestClient(tileserver.app)
-    r = client.get('/tiles/cm93/0/0/0?fmt=mvt')
+    r = client.get('/tiles/enc/0/0/0?fmt=mvt')
     assert r.status_code == 200
     assert r.content == tile
+    assert r.headers['content-type'] == 'application/x-protobuf'

--- a/VDR/chart-tiler/tests/test_metrics_idempotent.py
+++ b/VDR/chart-tiler/tests/test_metrics_idempotent.py
@@ -1,0 +1,30 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import prometheus_client
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def load_module(tag: str):
+    spec = importlib.util.spec_from_file_location(f"tileserver_{tag}", ROOT / "tileserver.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+
+def test_metrics_idempotent(monkeypatch):
+    reg = prometheus_client.CollectorRegistry()
+    prometheus_client.registry.REGISTRY = reg
+    prometheus_client.metrics.REGISTRY = reg
+
+    m1 = load_module("a")
+    count1 = len(list(m1._prom_registry.collect()))
+
+    m2 = load_module("b")
+    count2 = len(list(m2._prom_registry.collect()))
+
+    assert count1 == count2

--- a/VDR/chart-tiler/tests/test_scamin_mapping.py
+++ b/VDR/chart-tiler/tests/test_scamin_mapping.py
@@ -23,7 +23,7 @@ def test_monotonic_and_clamped() -> None:
 def test_respect_scamin_default(monkeypatch, tmp_path) -> None:
     calls = {}
 
-    def fake_s57_to_mbtiles(path, mbtiles, respect_scamin=True, scamin_map=None):
+    def fake_s57_to_mbtiles(path, mbtiles, respect_scamin=True, scamin_map=None, minzoom=5, maxzoom=14):
         calls["respect"] = respect_scamin
 
     def fake_s57_to_cog(*args, **kwargs):

--- a/VDR/chart-tiler/tools/make_mbtiles_fixture.py
+++ b/VDR/chart-tiler/tools/make_mbtiles_fixture.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Create a tiny ENC MBTiles fixture for tests.
+
+The fixture contains a single tile (z0/x0/y0) with a couple of synthetic
+features so that the vector tile is non-empty.  The goal is to provide a
+network-free sample for unit tests and local development when real ENC data is
+unavailable.  The resulting file is intentionally tiny and is not meant for
+navigation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+from typing import List, Dict
+
+from mvt_builder import encode_mvt  # type: ignore
+
+
+def _build_features(include_scamin: bool) -> List[Dict]:
+    feats: List[Dict] = []
+    props: Dict[str, object]
+
+    # Simple land area polygon
+    props = {"OBJL": "LNDARE"}
+    if include_scamin:
+        props["SCAMIN"] = 45000
+    feats.append(
+        {
+            "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]},
+            "properties": props,
+        }
+    )
+
+    # Depth area
+    props = {"OBJL": "DEPARE", "DRVAL1": 0, "DRVAL2": 5}
+    if include_scamin:
+        props["SCAMIN"] = 45000
+    feats.append({"geometry": {"type": "Polygon", "coordinates": [[[0.2, 0.2], [0.8, 0.2], [0.8, 0.8], [0.2, 0.8], [0.2, 0.2]]]}, "properties": props})
+
+    # Contour line
+    props = {"OBJL": "DEPCNT", "VALDCO": 10}
+    if include_scamin:
+        props["SCAMIN"] = 45000
+    feats.append({"geometry": {"type": "LineString", "coordinates": [[0, 0.5], [1, 0.5]]}, "properties": props})
+
+    # Sounding
+    props = {"OBJL": "SOUNDG", "VALSOU": 3}
+    if include_scamin:
+        props["SCAMIN"] = 45000
+    feats.append({"geometry": {"type": "Point", "coordinates": [0.5, 0.5]}, "properties": props})
+
+    return feats
+
+
+def make_fixture(path: Path, include_scamin: bool) -> None:
+    feats = _build_features(include_scamin)
+    tile = encode_mvt(feats)
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE metadata (name TEXT, value TEXT)")
+    cur.execute("CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB)")
+    cur.executemany(
+        "INSERT INTO metadata VALUES (?,?)",
+        [
+            ("name", "enc_fixture"),
+            ("format", "pbf"),
+            ("bounds", "0,0,1,1"),
+            ("minzoom", "0"),
+            ("maxzoom", "14"),
+        ],
+    )
+    cur.execute("INSERT INTO tiles VALUES (0,0,0,?)", (sqlite3.Binary(tile),))
+    conn.commit()
+    conn.close()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--out", required=True, help="Output .mbtiles path")
+    p.add_argument("--scamin", action="store_true", help="Include SCAMIN attributes")
+    args = p.parse_args()
+    make_fixture(Path(args.out), args.scamin)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/VDR/docs/PR_SUMMARY_PHASE12_ENC_ONLINE.md
+++ b/VDR/docs/PR_SUMMARY_PHASE12_ENC_ONLINE.md
@@ -1,0 +1,23 @@
+# Phase 12 – ENC Online
+
+* encode S‑57 to MBTiles with SCAMIN aware minzoom
+* tileserver streams `/tiles/enc` from MBTiles with private metrics registry
+* frontend defaults to ENC base and propagates mariner parameters
+* docs describe local ENC ingestion and MBTiles format
+
+## Commands
+
+```
+python VDR/chart-tiler/tools/make_mbtiles_fixture.py --out VDR/chart-tiler/data/enc/sample.mbtiles --scamin
+uvicorn VDR.chart-tiler.tileserver:app --reload
+curl -s localhost:8000/charts?kind=enc | jq .
+```
+
+## Perf Notes
+
+LRU cache size tunable via `MBTILES_CACHE_SIZE`.
+
+## Risks & Rollback
+
+Fallback to previous CM93 endpoint is retained.  Remove `MBTILES_PATH` to disable
+ENC serving.

--- a/VDR/docs/enc_mbtiles.md
+++ b/VDR/docs/enc_mbtiles.md
@@ -1,0 +1,28 @@
+# ENC MBTiles
+
+MBTiles produced from S‑57 or CM93 cells are served as the primary ENC vector
+base.  Each database contains a single `pbf` tile layer with features carrying
+selected S‑57 attributes such as `OBJL`, `OBJNAM`, `NOBJNM` and `SCAMIN`.
+
+## SCAMIN mapping
+
+Features with a `SCAMIN` attribute are mapped to Mapbox Vector Tile zoom levels
+using the following table:
+
+| SCAMIN | minzoom |
+|-------:|--------:|
+| 90 000 | 10 |
+| 45 000 | 11 |
+| 22 000 | 12 |
+| 12 000 | 13 |
+| 8 000  | 14 |
+| 4 000  | 15 |
+| 2 000  | 16 |
+
+Values outside the table are clamped to the nearest zoom.
+
+## Troubleshooting
+
+* `tippecanoe` missing – ensure it is installed and available on the `PATH`.
+* empty tiles – verify the source `.000` file contains features.
+* SCAMIN ignored – pass `--respect-scamin` to the encoder.

--- a/VDR/docs/operator_runbook.md
+++ b/VDR/docs/operator_runbook.md
@@ -35,6 +35,17 @@ python VDR/chart-tiler/tools/import_geotiff.py --src /charts/raster/harbor.tif
 curl -X POST localhost:8000/charts/scan
 ```
 
+### Import ENC locally
+
+When real cells are unavailable (e.g. in CI) synthesise a tiny fixture and
+register it with the tiler:
+
+```bash
+python VDR/chart-tiler/tools/make_mbtiles_fixture.py \
+  --out VDR/chart-tiler/data/enc/sample.mbtiles --scamin
+curl -X POST localhost:8000/charts/scan
+```
+
 ## Select Base Map
 
 The web client reads `/charts` to populate the base picker.  Toggle between

--- a/VDR/web-client/package.json
+++ b/VDR/web-client/package.json
@@ -11,6 +11,6 @@
     "zustand": "^4.5.2"
   },
   "scripts": {
-    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS=\"{\\\"jsx\\\":\\\"react\\\",\\\"module\\\":\\\"commonjs\\\"}\" node -r ts-node/register src/components/AppMap.test.ts && TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS=\"{\\\"jsx\\\":\\\"react\\\",\\\"module\\\":\\\"commonjs\\\"}\" node -r ts-node/register src/components/test_appmap_bases.spec.ts && TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS=\"{\\\"jsx\\\":\\\"react\\\",\\\"module\\\":\\\"commonjs\\\"}\" node -r ts-node/register src/components/__tests__/base_picker.spec.ts"
+    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS=\"{\\\"jsx\\\":\\\"react\\\",\\\"module\\\":\\\"commonjs\\\"}\" node -r ts-node/register src/components/AppMap.test.ts && TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS=\"{\\\"jsx\\\":\\\"react\\\",\\\"module\\\":\\\"commonjs\\\"}\" node -r ts-node/register src/components/test_appmap_bases.spec.ts && TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS=\"{\\\"jsx\\\":\\\"react\\\",\\\"module\\\":\\\"commonjs\\\"}\" node -r ts-node/register src/components/__tests__/base_picker.spec.ts && TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS=\"{\\\"jsx\\\":\\\"react\\\",\\\"module\\\":\\\"commonjs\\\"}\" node -r ts-node/register src/components/__tests__/AppMap.enc.spec.ts"
   }
 }

--- a/VDR/web-client/src/components/AppMap.test.ts
+++ b/VDR/web-client/src/components/AppMap.test.ts
@@ -4,7 +4,7 @@ import { createMapAPI } from './AppMap';
 function mockMap() {
   return {
     layout: [] as any[],
-    style: { sources: { cm93: { tiles: ['old'] } } },
+    style: { sources: { enc: { tiles: ['old'] } } },
     setLayoutProperty(id: string, prop: string, value: string) {
       this.layout.push([id, prop, value]);
     },
@@ -23,5 +23,5 @@ const api = createMapAPI(map);
 api.toggleLayer('SOUNDG', false);
 assert.deepStrictEqual(map.layout[0], ['SOUNDG', 'visibility', 'none']);
 api.setMarinerParams({ safety: 12 });
-assert.ok(map.last.sources.cm93.tiles[0].includes('safety=12'));
+assert.ok(map.last.sources.enc.tiles[0].includes('safety=12'));
 console.log('ok');

--- a/VDR/web-client/src/components/AppMap.tsx
+++ b/VDR/web-client/src/components/AppMap.tsx
@@ -12,10 +12,10 @@ export function createMapAPI(map: any) {
   return {
     setMarinerParams(p: Partial<MarinerParams>) {
       Object.assign(params, p);
-      const style = map.getStyle ? map.getStyle() : { sources: { cm93: { tiles: [] } } };
+      const style = map.getStyle ? map.getStyle() : { sources: { enc: { tiles: [] } } };
       const { safety, shallow, deep } = params;
-      style.sources.cm93.tiles = [
-        `/tiles/cm93/{z}/{x}/{y}?fmt=mvt&safety=${safety}&shallow=${shallow}&deep=${deep}`,
+      style.sources.enc.tiles = [
+        `/tiles/enc/{z}/{x}/{y}?fmt=mvt&safety=${safety}&shallow=${shallow}&deep=${deep}`,
       ];
       map.setStyle(style);
     },
@@ -52,8 +52,9 @@ export function createMapAPI(map: any) {
       } else if (base === 'enc') {
         style.sources.base = {
           type: 'vector',
-          tiles: ['/tiles/cm93/{z}/{x}/{y}?fmt=mvt'],
+          tiles: ['/tiles/enc/{z}/{x}/{y}?fmt=mvt'],
         };
+        style.sources.enc = style.sources.base;
       }
       map.setStyle(style);
     },

--- a/VDR/web-client/src/components/__tests__/AppMap.enc.spec.ts
+++ b/VDR/web-client/src/components/__tests__/AppMap.enc.spec.ts
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import { createMapAPI } from '../AppMap';
+
+function mockMap() {
+  return {
+    style: { sources: {} as any },
+    setStyle(s: any) { this.style = s; },
+    getStyle() { return this.style; },
+    layout: [] as any[],
+    setLayoutProperty(id: string, prop: string, value: string) {
+      this.layout.push([id, prop, value]);
+    },
+  } as any;
+}
+
+const map = mockMap();
+const api = createMapAPI(map);
+api.setBase('enc');
+assert.ok(map.style.sources.base.tiles[0].includes('/tiles/enc'));
+api.setMarinerParams({ safety: 9 });
+assert.ok(map.style.sources.enc.tiles[0].includes('safety=9'));
+console.log('enc ok');


### PR DESCRIPTION
## Summary
- stream ENC MBTiles via new /tiles/enc endpoint with dataset-aware cache keys
- plumb SCAMIN through preclassifier and expose MBTiles encoder helper
- default web client to ENC base and document local ENC ingestion

## Testing
- `pytest -q VDR/chart-tiler/tests/test_mbtiles_stream.py`
- `pytest -q VDR/chart-tiler/tests/test_registry_scan.py`
- `pytest -q VDR/chart-tiler/tests/test_scamin_mapping.py`
- `pytest -q VDR/chart-tiler/tests/test_metrics_idempotent.py`
- `npm test --prefix VDR/web-client`

------
https://chatgpt.com/codex/tasks/task_e_68a0873f5714832a885282e6f403b0d3