### PR TITLE
docs: update phase summary tests

### DIFF
--- a/VDR/docs/PR_SUMMARY_PHASE_1_3_1_TO_1_4_1.md
+++ b/VDR/docs/PR_SUMMARY_PHASE_1_3_1_TO_1_4_1.md
@@ -29,7 +29,6 @@ and refreshing the registry.
 - `pytest VDR/chart-tiler/tests/test_convert_geotiff.py`
 - `pytest VDR/chart-tiler/tests/test_registry_scan.py`
 - `pytest VDR/chart-tiler/tests/test_tiles_geotiff.py`
-- `pytest VDR/chart-tiler/tests/test_charts_api.py`
 - `pytest VDR/chart-tiler/tests/test_tileserver_health.py`
 - `pytest VDR/chart-tiler/tests/test_tiles_geotiff_real.py || true`
 - `pytest VDR/server-styling/tests/test_depths_and_hazards.py`


### PR DESCRIPTION
## Summary
- remove outdated charts API test reference from phase summary

## Testing
- `pytest VDR/chart-tiler/tests/test_convert_geotiff.py`
- `pytest VDR/chart-tiler/tests/test_registry_scan.py`
- `pytest VDR/chart-tiler/tests/test_tiles_geotiff.py`
- `npm test --prefix VDR/web-client`
- `pytest VDR/chart-tiler/tests/test_charts_api.py` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a097bf681c832a85a7e8ae6d7cce7c