### PR TITLE
Stage local S-52 assets from repo data

### DIFF
--- a/VDR/docs/s52s57cm93.md
+++ b/VDR/docs/s52s57cm93.md
@@ -29,7 +29,7 @@ python VDR/server-styling/sync_opencpn_assets.py \
   --lock VDR/server-styling/opencpn-assets.lock \
   --dest VDR/server-styling/dist/assets/s52 --force
 ```
-- Local assets from `data/s57data/`:
+- Local assets from OpenCPN root `data/s57data/`:
 
 ```
 python VDR/server-styling/tools/stage_local_assets.py \

--- a/VDR/server-styling/.gitignore
+++ b/VDR/server-styling/.gitignore
@@ -1,4 +1,5 @@
 # Generated assets and binary artefacts
+dist/assets/
 dist/assets/s52/
 dist/sprites/*.png
 dist/*.png

--- a/VDR/server-styling/tests/test_stage_assets.py
+++ b/VDR/server-styling/tests/test_stage_assets.py
@@ -1,0 +1,66 @@
+"""Tests for ``stage_local_assets.py``.
+
+The test exercises the staging helper using repository‑local assets.  It is
+written to be skip‑safe – if the ``data/s57data`` directory is missing the
+test will skip rather than fail so CI environments without the data can still
+run the rest of the suite.
+"""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = ROOT.parent
+SCRIPT = ROOT / "server-styling" / "tools" / "stage_local_assets.py"
+
+ASSETS = [
+    "chartsymbols.xml",
+    "rastersymbols-day.png",
+    "S52RAZDS.RLE",
+    "s57objectclasses.csv",
+    "s57attributes.csv",
+    "attdecode.csv",
+]
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def test_stage_assets(tmp_path: Path) -> None:
+    repo_data = REPO_ROOT / "data" / "s57data"
+    if not repo_data.exists():
+        pytest.skip("s57 data missing")
+
+    dest = tmp_path / "assets" / "s52"
+    subprocess.check_call(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-data",
+            str(repo_data),
+            "--dest",
+            str(dest),
+            "--force",
+        ]
+    )
+
+    manifest_path = dest / "assets.manifest.json"
+    with manifest_path.open() as fh:
+        manifest = json.load(fh)
+
+    assert set(manifest) == set(ASSETS)
+    for name in ASSETS:
+        file_path = dest / name
+        assert file_path.is_file()
+        assert manifest[name] == _sha256(file_path)
+

--- a/VDR/server-styling/tools/stage_local_assets.py
+++ b/VDR/server-styling/tools/stage_local_assets.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Stage S-52/S-57 assets from a repo-local data directory."""
+"""Stage a minimal set of OpenCPN S‑52/S‑57 assets.
+
+This helper copies a handful of binary assets from the repository checkout
+into a build directory.  A JSON manifest containing SHA‑256 checksums is
+written alongside the files which allows downstream build steps to verify the
+contents without shipping the binaries in Git.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -7,7 +14,10 @@ import hashlib
 import json
 import shutil
 from pathlib import Path
+from typing import Dict
 
+
+# Filenames relative to the ``data/s57data`` directory in the repository.
 ASSETS = [
     "chartsymbols.xml",
     "rastersymbols-day.png",
@@ -18,52 +28,68 @@ ASSETS = [
 ]
 
 
-def _hash_path(path: Path) -> str:
+def _sha256(path: Path) -> str:
     h = hashlib.sha256()
-    h.update(path.read_bytes())
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(8192), b""):
+            h.update(chunk)
     return h.hexdigest()
 
 
-def stage_assets(
-    repo_data: Path, dest: Path, force: bool
-) -> tuple[dict[str, str], list[str]]:
-    manifest: dict[str, str] = {}
-    missing: list[str] = []
+def stage_assets(repo_data: Path, dest: Path, force: bool = False) -> Dict[str, str]:
+    """Copy assets from ``repo_data`` into ``dest``.
+
+    :param repo_data: Path to the ``data/s57data`` directory in the OpenCPN
+        repository.
+    :param dest: Destination directory for staged assets.
+    :param force: Overwrite ``dest`` if it already exists.
+    :returns: Mapping of filenames to SHA‑256 checksums.
+    :raises FileNotFoundError: if any required asset is missing.
+    :raises FileExistsError: if ``dest`` exists and ``force`` is ``False``.
+    """
+
+    repo_data = Path(repo_data)
+    dest = Path(dest)
+
+    missing = [name for name in ASSETS if not (repo_data / name).is_file()]
+    if missing:
+        raise FileNotFoundError(
+            "missing assets in repo: " + ", ".join(sorted(missing))
+        )
+
+    if dest.exists():
+        if force:
+            shutil.rmtree(dest)
+        else:
+            raise FileExistsError(f"{dest} exists; use --force to overwrite")
+
     dest.mkdir(parents=True, exist_ok=True)
+
+    manifest: Dict[str, str] = {}
     for name in ASSETS:
         src = repo_data / name
-        if not src.exists():
-            missing.append(name)
-            continue
         dst = dest / name
-        if dst.exists() and not force:
-            if dst.read_bytes() == src.read_bytes():
-                manifest[name] = _hash_path(dst)
-                continue
         shutil.copy2(src, dst)
-        manifest[name] = _hash_path(dst)
-    if manifest:
-        (dest / "assets.manifest.json").write_text(
-            json.dumps(manifest, indent=2, sort_keys=True)
-        )
-    return manifest, missing
+        manifest[name] = _sha256(dst)
+
+    (dest / "assets.manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    return manifest
 
 
 def main() -> int:  # pragma: no cover - CLI helper
-    p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--repo-data", type=Path, required=True)
-    p.add_argument("--dest", type=Path, required=True)
-    p.add_argument("--force", action="store_true")
-    args = p.parse_args()
-    manifest, missing = stage_assets(args.repo_data, args.dest, args.force)
-    if manifest:
-        print(f"Staged {len(manifest)} assets")
-    else:
-        print("No assets staged")
-    if missing:
-        print("Missing assets: " + ", ".join(sorted(missing)))
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-data", type=Path, required=True)
+    parser.add_argument("--dest", type=Path, required=True)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    manifest = stage_assets(args.repo_data, args.dest, args.force)
+    print(f"Staged {len(manifest)} assets")
     return 0
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI helper
     raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add helper to stage local OpenCPN S-52/S-57 assets with checksum manifest
- document local asset staging and ignore staged binaries
- test staging helper against repository data

## Testing
- `python VDR/server-styling/tools/stage_local_assets.py --repo-data data/s57data --dest VDR/server-styling/dist/assets/s52 --force`
- `pytest VDR/server-styling/tests/test_stage_assets.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e24b3794832a9e7898eac989c5b4