### PR TITLE
Add import_enc shim and configure PYTHONPATH in CI

### DIFF
--- a/.github/workflows/stage-and-test.yml
+++ b/.github/workflows/stage-and-test.yml
@@ -33,6 +33,10 @@ jobs:
           if [ -f VDR/requirements.txt ]; then pip install -r VDR/requirements.txt; fi
           pip install pytest
 
+      - name: Set PYTHONPATH for tests
+        run: |
+          echo "PYTHONPATH=VDR:VDR/chart-tiler:${PYTHONPATH}" >> $GITHUB_ENV
+
       - name: Install Web deps (best effort)
         run: |
           if [ -f VDR/web-client/package.json ]; then npm ci --prefix VDR/web-client; fi
@@ -49,8 +53,7 @@ jobs:
 
       - name: Python tests
         run: |
-          pytest -q VDR || true
-          # If you want strict failures, remove '|| true'
+          pytest -q VDR
 
       - name: Web tests
         run: |

--- a/VDR/chart-tiler/tools/__init__.py
+++ b/VDR/chart-tiler/tools/__init__.py
@@ -1,0 +1,1 @@
+# Makes 'tools' a normal package for imports in tests/CI.

--- a/VDR/import_enc.py
+++ b/VDR/import_enc.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+Shim module to make `import_enc` importable as a top-level module in CI and tests.
+
+It re-exports everything from VDR/chart-tiler/tools/import_enc.py by temporarily
+adding the chart-tiler folder to sys.path (the folder name contains a hyphen,
+so it cannot be imported as a normal package).
+"""
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+# Add .../VDR/chart-tiler to sys.path so `from tools import import_enc` resolves
+CHART_TILER_DIR = Path(__file__).resolve().parent / "chart-tiler"
+if str(CHART_TILER_DIR) not in sys.path:
+    sys.path.insert(0, str(CHART_TILER_DIR))
+
+# Re-export public API
+from tools.import_enc import *  # type: ignore  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- expose chart-tiler `import_enc` as top-level module
- ensure `tools` is a package
- export `PYTHONPATH` in stage-and-test workflow for Python tests

## Testing
- `python -c "import import_enc; print(import_enc.__doc__[:60])"`
- `pytest -q VDR/chart-tiler/tests/test_import_enc.py::test_import_enc`


------
https://chatgpt.com/codex/tasks/task_e_68a10235180c832a873b5600c0a6dce7