### PR TITLE
Add tile server metrics and performance budgets

### DIFF
--- a/VDR/chart-tiler/.github/workflows/ci.yml
+++ b/VDR/chart-tiler/.github/workflows/ci.yml
@@ -20,3 +20,5 @@ jobs:
         run: pip install -r VDR/chart-tiler/requirements.txt
       - name: Run tests
         run: pytest VDR/chart-tiler/tests
+      - name: Enforce performance budgets
+        run: pytest VDR/chart-tiler/tests/test_perf_tiles.py

--- a/VDR/chart-tiler/metrics.py
+++ b/VDR/chart-tiler/metrics.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Prometheus metrics for tile rendering."""
+
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, Histogram, generate_latest
+
+REGISTRY = CollectorRegistry()
+
+# Histogram tracking tile rendering latency by endpoint kind
+# (e.g. cm93-core, cm93-label, geotiff).
+tile_render_seconds = Histogram(
+    "tile_render_seconds",
+    "Latency for tile rendering in seconds",
+    ["kind"],
+    registry=REGISTRY,
+)
+
+# Counter recording total bytes returned per endpoint kind.
+tile_bytes_total = Counter(
+    "tile_bytes_total",
+    "Total bytes returned for tiles",
+    ["kind"],
+    registry=REGISTRY,
+)
+
+__all__ = [
+    "REGISTRY",
+    "tile_render_seconds",
+    "tile_bytes_total",
+    "CONTENT_TYPE_LATEST",
+    "generate_latest",
+]

--- a/VDR/chart-tiler/tests/test_perf_tiles.py
+++ b/VDR/chart-tiler/tests/test_perf_tiles.py
@@ -1,0 +1,45 @@
+import sys
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+DIST = ROOT.parent / "server-styling" / "dist"
+
+# Ensure minimal styling assets exist for server import
+(DIST / "sprites").mkdir(parents=True, exist_ok=True)
+(DIST / "assets" / "s52").mkdir(parents=True, exist_ok=True)
+(DIST / "sprites" / "s52-day.json").write_text("{}")
+(DIST / "assets" / "s52" / "chartsymbols.xml").write_text("<root/>")
+
+import tileserver
+
+client = TestClient(tileserver.app)
+
+
+def _p90(values: list[float]) -> float:
+    values = sorted(values)
+    idx = max(int(len(values) * 0.9) - 1, 0)
+    return values[idx]
+
+
+def _check(path: str, max_size: int) -> None:
+    # warm cache
+    client.get(path)
+    durations = []
+    sizes = []
+    for _ in range(10):
+        start = time.perf_counter()
+        r = client.get(path)
+        durations.append(time.perf_counter() - start)
+        sizes.append(len(r.content))
+    assert _p90(durations) * 1000 < 150
+    assert max(sizes) < max_size
+
+
+def test_perf_tiles() -> None:
+    _check("/tiles/cm93-core/8/0/0.pbf", 200 * 1024)
+    _check("/tiles/cm93-core/12/0/0.pbf", 200 * 1024)
+    _check("/tiles/cm93-core/15/0/0.pbf", 400 * 1024)

--- a/VDR/chart-tiler/tests/test_tileserver.py
+++ b/VDR/chart-tiler/tests/test_tileserver.py
@@ -107,12 +107,19 @@ def test_style_palettes_differ() -> None:
 
 
 def test_metrics_endpoint() -> None:
+    # Trigger metric collection
+    client.get("/tiles/cm93-core/0/0/0.pbf")
     r = client.get("/metrics")
     assert r.status_code == 200
-    assert b"tile_gen_ms" in r.content
+    assert b"tile_render_seconds" in r.content
+    assert b"tile_bytes_total" in r.content
 
 
 def test_metrics_endpoint_idempotent_import() -> None:
+    # Ensure minimal color table exists for reload
+    (DIST / "assets" / "s52" / "chartsymbols.xml").write_text(
+        "<root><color-table name='DAY_BRIGHT'></color-table></root>"
+    )
     mod = importlib.reload(tileserver)
     new_client = TestClient(mod.app)
     r = new_client.get("/metrics")

--- a/VDR/docs/CHANGELOG.md
+++ b/VDR/docs/CHANGELOG.md
@@ -14,3 +14,5 @@
   mariner parameters applied via style expressions instead of URL
   parameters. Added UI toggles for label plane visibility and palette
   selection.
+- Exposed Prometheus metrics for tile latency and size and added CI
+  performance-gate tests enforcing latency and payload budgets.

--- a/VDR/docs/ops/nginx.md
+++ b/VDR/docs/ops/nginx.md
@@ -1,0 +1,40 @@
+# Nginx Ops Notes
+
+These snippets show how to enable modern transport and compression when serving
+chart tiles.
+
+## Compression with Brotli and Zstandard
+
+```nginx
+load_module modules/ngx_http_brotli_filter_module.so;
+load_module modules/ngx_http_brotli_static_module.so;
+load_module modules/ngx_http_zstd_filter_module.so;
+load_module modules/ngx_http_zstd_static_module.so;
+
+server {
+    brotli on;
+    brotli_static on;
+    brotli_types application/json application/x-protobuf;
+
+    zstd  on;
+    zstd_static on;
+    zstd_types application/json application/x-protobuf;
+}
+```
+
+## HTTP/3
+
+```nginx
+server {
+    listen 443 ssl http2;         # HTTP/2 fallback
+    listen 443 quic reuseport;    # HTTP/3
+    ssl_certificate     /etc/ssl/cert.pem;
+    ssl_certificate_key /etc/ssl/key.pem;
+
+    add_header Alt-Svc 'h3=":443"';
+}
+```
+
+Enable [Brotli](https://github.com/google/ngx_brotli) and
+[Zstandard](https://github.com/tokers/zstd-nginx-module) modules at build time
+or via dynamic modules.

--- a/VDR/docs/perf_budgets.md
+++ b/VDR/docs/perf_budgets.md
@@ -1,0 +1,13 @@
+# Performance Budgets
+
+The tile server enforces lightweight performance gates during CI.
+
+* **Latency:** 90th percentile response time for cached vector tiles must be
+  below **150&nbsp;ms**.
+* **Payload size:** Vector tiles at zoom levels 0–12 must remain under
+  **200&nbsp;KB**.  Tiles at zoom 13 and above may not exceed **400&nbsp;KB**.
+
+These thresholds are verified by `test_perf_tiles.py`.  Alerting can be wired to
+Prometheus by scraping the `/metrics` endpoint and firing alerts when
+`tile_render_seconds` or `tile_bytes_total` exceed these limits for sustained
+periods.

--- a/VDR/pytest.ini
+++ b/VDR/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.minimal_settings
-testpaths = tests
+testpaths =
+    tests
+    chart-tiler/tests


### PR DESCRIPTION
## Summary
- expose Prometheus metrics for tile latency and payload size
- add performance budget tests and CI enforcement
- document nginx compression and perf thresholds

## Testing
- `pytest VDR/chart-tiler/tests/test_tileserver.py VDR/chart-tiler/tests/test_perf_tiles.py`
- `pytest VDR/chart-tiler/tests` *(fails: ModuleNotFoundError: No module named 'import_enc')*

------
https://chatgpt.com/codex/tasks/task_e_68a19faddb5c832aa6b8204c272db9f1