### PR TITLE
Document tile performance budgets and add Prometheus metrics

### DIFF
--- a/VDR/chart-tiler/metrics.py
+++ b/VDR/chart-tiler/metrics.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 """Prometheus metrics for tile rendering."""
 
-from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, Histogram, generate_latest
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
 
 REGISTRY = CollectorRegistry()
 
@@ -23,10 +30,27 @@ tile_bytes_total = Counter(
     registry=REGISTRY,
 )
 
+# Gauge recording size in bytes of the most recent tile response per endpoint kind.
+tile_size_bytes = Gauge(
+    "tile_size_bytes",
+    "Size of the last tile rendered in bytes",
+    ["kind"],
+    registry=REGISTRY,
+)
+
+# Gauge tracking resident memory usage of the tile server process.
+process_resident_memory_bytes = Gauge(
+    "process_resident_memory_bytes",
+    "Resident memory used by the tile server in bytes",
+    registry=REGISTRY,
+)
+
 __all__ = [
     "REGISTRY",
     "tile_render_seconds",
     "tile_bytes_total",
+    "tile_size_bytes",
+    "process_resident_memory_bytes",
     "CONTENT_TYPE_LATEST",
     "generate_latest",
 ]

--- a/VDR/docs/perf_budgets.md
+++ b/VDR/docs/perf_budgets.md
@@ -2,12 +2,43 @@
 
 The tile server enforces lightweight performance gates during CI.
 
-* **Latency:** 90th percentile response time for cached vector tiles must be
+* **Latency:** 95th percentile response time for cached vector tiles must stay
   below **150&nbsp;ms**.
 * **Payload size:** Vector tiles at zoom levels 0–12 must remain under
-  **200&nbsp;KB**.  Tiles at zoom 13 and above may not exceed **400&nbsp;KB**.
+  **200&nbsp;KB**. Tiles at zoom **13 and above** may not exceed **400&nbsp;KB**.
+* **Memory:** Resident set size of the tile server process should remain under
+  **1 GiB**.
 
-These thresholds are verified by `test_perf_tiles.py`.  Alerting can be wired to
-Prometheus by scraping the `/metrics` endpoint and firing alerts when
-`tile_render_seconds` or `tile_bytes_total` exceed these limits for sustained
-periods.
+These thresholds are verified by `tests/perf/test_tile_latency.py`. Metrics are
+exported via the `/metrics` endpoint using Prometheus format.
+
+### Sample Prometheus Alerts
+
+```yaml
+- alert: TileLatencyHigh
+  expr: histogram_quantile(0.95, sum(rate(tile_render_seconds_bucket[5m])) by (le,kind)) > 0.15
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    summary: "High tile latency for {{ $labels.kind }}"
+    description: "95th percentile tile latency exceeded 150ms for 10m"
+
+- alert: TileSizeTooLarge
+  expr: max_over_time(tile_size_bytes[5m]) > 400 * 1024
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Large tiles for {{ $labels.kind }}"
+    description: "Vector tile size exceeded budget"
+
+- alert: TileServerHighMemory
+  expr: process_resident_memory_bytes > 1e9
+  for: 15m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Tile server memory high"
+    description: "Resident memory usage over 1 GiB"
+```

--- a/VDR/tests/perf/test_tile_latency.py
+++ b/VDR/tests/perf/test_tile_latency.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2] / "chart-tiler"
 sys.path.insert(0, str(ROOT))
 DIST = ROOT.parent / "server-styling" / "dist"
 
@@ -16,32 +16,32 @@ DIST = ROOT.parent / "server-styling" / "dist"
     "<root><color-table name='DAY_BRIGHT'><color name='X' r='0' g='0' b='0'/></color-table></root>"
 )
 
-import tileserver
+import tileserver  # noqa: E402
 
 client = TestClient(tileserver.app)
 
 
-def _p90(values: list[float]) -> float:
+def _p95(values: list[float]) -> float:
     values = sorted(values)
-    idx = max(int(len(values) * 0.9) - 1, 0)
+    idx = max(int(len(values) * 0.95) - 1, 0)
     return values[idx]
 
 
 def _check(path: str, max_size: int) -> None:
     # warm cache
     client.get(path)
-    durations = []
-    sizes = []
+    durations: list[float] = []
+    sizes: list[int] = []
     for _ in range(10):
         start = time.perf_counter()
         r = client.get(path)
         durations.append(time.perf_counter() - start)
         sizes.append(len(r.content))
-    assert _p90(durations) * 1000 < 150
+    assert _p95(durations) * 1000 < 150
     assert max(sizes) < max_size
 
 
-def test_perf_tiles() -> None:
+def test_tile_latency() -> None:
     _check("/tiles/cm93-core/8/0/0.pbf", 200 * 1024)
     _check("/tiles/cm93-core/12/0/0.pbf", 200 * 1024)
-    _check("/tiles/cm93-core/15/0/0.pbf", 400 * 1024)
+    _check("/tiles/cm93-core/13/0/0.pbf", 400 * 1024)


### PR DESCRIPTION
## Summary
- add gauges for tile size and resident memory to metrics and tileserver
- document latency, size and memory budgets with sample Prometheus alerts
- test fixed scenes to ensure tiles stay within latency and size budgets

## Testing
- `pre-commit run --files VDR/chart-tiler/metrics.py VDR/chart-tiler/tileserver.py VDR/docs/perf_budgets.md VDR/tests/perf/test_tile_latency.py VDR/chart-tiler/tests/test_perf_tiles.py`
- `pytest VDR/tests/perf/test_tile_latency.py VDR/chart-tiler/tests/test_perf_tiles.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1a88520c8832a89ab6901078c316a