### PR TITLE
Add license scanner and enforce host allowlist for asset fetches

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,18 @@
+name: License Scan
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install scanner
+        run: pip install scancode-toolkit
+      - name: Run license scan
+        run: python VDR/tools/license_scan.py --output license.spdx.json

--- a/VDR/server-styling/sync_opencpn_assets.py
+++ b/VDR/server-styling/sync_opencpn_assets.py
@@ -18,6 +18,20 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from urllib.parse import urlparse
+
+ALLOWLIST = Path(__file__).resolve().parents[1] / "tools" / "allowlist.txt"
+
+
+def _load_allowlist(path: Path) -> set[str]:
+    hosts: set[str] = set()
+    if not path.exists():
+        return hosts
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            hosts.add(line)
+    return hosts
 
 REQUIRED_FILES = {
     "chartsymbols.xml",
@@ -106,6 +120,11 @@ def main() -> None:  # pragma: no cover - thin CLI wrapper
         repo = lock["repo"]
         repo_path = lock["path"].strip("/")
         commit = lock["commit"]
+
+        allow_hosts = _load_allowlist(ALLOWLIST)
+        host = urlparse(repo).hostname
+        if host and allow_hosts and host not in allow_hosts:
+            raise SystemExit(f"Host '{host}' not in allowlist {ALLOWLIST}")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)

--- a/VDR/tools/allowlist.txt
+++ b/VDR/tools/allowlist.txt
@@ -1,0 +1,3 @@
+# Permitted hosts for asset downloads
+github.com
+openmaptiles.github.io

--- a/VDR/tools/license_scan.py
+++ b/VDR/tools/license_scan.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Scan project licenses using scancode-toolkit and emit an SPDX summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Dict
+import sys
+
+
+def run_scancode(scan_path: Path) -> Dict:
+    with tempfile.NamedTemporaryFile(suffix=".json") as tmp:
+        cmd = [
+            "scancode",
+            "--quiet",
+            "--json-pp",
+            tmp.name,
+            str(scan_path),
+        ]
+        subprocess.run(cmd, check=True)
+        data = json.loads(Path(tmp.name).read_text())
+    return data
+
+
+def build_spdx(data: Dict) -> Dict:
+    files = []
+    unknown = []
+    for entry in data.get("files", []):
+        lic = entry.get("license_expression") or "NOASSERTION"
+        path = entry.get("path")
+        files.append({"fileName": path, "licenseConcluded": lic})
+        if lic in {"unknown", "NOASSERTION"}:
+            unknown.append(path)
+    spdx = {
+        "SPDXVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "files": files,
+    }
+    return spdx, unknown
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", default=".", help="Path to scan")
+    parser.add_argument(
+        "--output", type=Path, help="Write SPDX JSON to file instead of stdout"
+    )
+    args = parser.parse_args()
+
+    data = run_scancode(Path(args.path))
+    spdx, unknown = build_spdx(data)
+
+    out = json.dumps(spdx, indent=2, sort_keys=True)
+    if args.output:
+        args.output.write_text(out)
+    else:
+        print(out)
+    if unknown:
+        for path in unknown:
+            print(f"Unknown license for {path}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `license_scan.py` wrapper for scancode and SPDX output
- enforce allowlist of asset hosts in sync and staging scripts
- run license scan in CI

## Testing
- `pytest VDR/server-styling/tests/test_stage_assets.py`
- `python VDR/tools/license_scan.py --help`
- `bash -n VDR/scripts/stage_assets_all.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a1a881725c832a8a32e05ab10ea6a7