### PR TITLE
ci: split vdr workflow jobs

### DIFF
--- a/.github/workflows/vdr.yml
+++ b/.github/workflows/vdr.yml
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/vdr.yml'
 
 jobs:
-  build:
+  style-sprite:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,8 +23,63 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r VDR/chart-tiler/requirements.txt pytest
+          pip install -r VDR/chart-tiler/requirements.txt
       - name: Build styling artifacts
         run: make all
-      - name: Run tests
+      - name: Upload styling artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: styling-dist
+          path: VDR/server-styling/dist
+
+  glyph-bake:
+    runs-on: ubuntu-latest
+    needs: style-sprite
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Download styling artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: styling-dist
+          path: VDR/server-styling/dist
+      - name: Bake glyph PBFs
+        run: |
+          npm install -g @mapbox/fontnik
+          mkdir -p VDR/server-styling/dist/glyphs
+          fontnik VDR/BAUV/lib/tileserver-gl/public/resources/fonts/OpenSans-Regular.ttf \
+            VDR/server-styling/dist/glyphs/OpenSans-Regular.pbf
+      - name: Upload glyphs
+        uses: actions/upload-artifact@v3
+        with:
+          name: glyphs
+          path: VDR/server-styling/dist/glyphs
+
+  tileserver-tests:
+    runs-on: ubuntu-latest
+    needs:
+      - style-sprite
+      - glyph-bake
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r VDR/chart-tiler/requirements.txt pytest
+      - name: Retrieve styling artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: styling-dist
+          path: VDR/server-styling/dist
+      - name: Retrieve glyphs
+        uses: actions/download-artifact@v3
+        with:
+          name: glyphs
+          path: VDR/server-styling/dist/glyphs
+      - name: Run tileserver tests
         run: pytest VDR/chart-tiler/tests

--- a/VDR/docs/ci.md
+++ b/VDR/docs/ci.md
@@ -1,0 +1,12 @@
+# Continuous Integration
+
+The VDR CI workflow is split into three jobs to build styling assets and run tests.
+
+- **style-sprite** – prepares S-52 styling JSON and sprite sheets.  The job uses
+  the repository Makefile to stage assets and publishes the `server-styling/dist`
+  directory as a workflow artifact.
+- **glyph-bake** – depends on Node.  It downloads the styling artifact, bakes
+  font glyphs into PBF ranges and uploads the resulting `glyphs/` directory as
+  an artifact.
+- **tileserver-tests** – retrieves the styling and glyph artifacts and runs the
+  chart tiler test-suite with `pytest` without accessing the network.


### PR DESCRIPTION
## Summary
- build styling assets in dedicated `style-sprite` job
- bake glyph PBFs in `glyph-bake` and pass via artifacts
- run tileserver pytest suite consuming artifacts

## Testing
- `python -m pip install --upgrade pip`
- `pip install -r VDR/chart-tiler/requirements.txt pytest`
- `pytest VDR/chart-tiler/tests` *(fails: 12 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68a1a87763e8832a884668e0935ca30b