### PR TITLE
feat: add BAUV adapter and sprite tooling

### DIFF
--- a/VDR/docs/bauv.md
+++ b/VDR/docs/bauv.md
@@ -1,0 +1,29 @@
+# BAUV Assets
+
+The BAUV project supplies a collection of nautical SVG symbols.  Only the
+symbols stored under `VDR/BAUV/src/public/svg` are consumed by the style builder
+and may be redistributed by this repository.  Additional files shipped with the
+upstream project are ignored.
+
+## Adapter
+
+`third_party/bauv_adapter.py` exposes a light‑weight API for accessing these
+assets from tooling.  Typical usage::
+
+```python
+from VDR.third_party import bauv_adapter
+
+for name, path in bauv_adapter.iter_symbols():
+    print(name, path)
+
+palette = bauv_adapter.load_palette()
+```
+
+The adapter intentionally returns paths and dictionaries; callers are free to
+rasterise the SVGs or interpret the palette as required.
+
+## Sprites
+
+`server-styling/tools/bauv_sprite.py` rasterises selected BAUV symbols using the
+`resvg` command line tool and packs them into a MapLibre compatible sprite sheet
+written to `server-styling/dist/sprites/`.

--- a/VDR/server-styling/dist/assets/bauv/PROVENANCE.txt
+++ b/VDR/server-styling/dist/assets/bauv/PROVENANCE.txt
@@ -1,0 +1,1 @@
+BAUV-Maps dad773ad9e58488ad167604858e0869ccb997ec7 SPDX-License-Identifier: NOASSERTION

--- a/VDR/server-styling/tools/bauv_sprite.py
+++ b/VDR/server-styling/tools/bauv_sprite.py
@@ -1,0 +1,76 @@
+"""Rasterise BAUV SVG symbols into a MapLibre sprite sheet.
+
+The script expects the BAUV assets to be vendored under ``VDR/BAUV`` and uses
+``resvg`` to convert individual SVGs into PNGs.  The generated sprite and JSON
+manifest are written to ``dist/sprites`` using the prefix ``bauv``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Dict, List
+
+import sys
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "third_party"))
+
+import bauv_adapter
+
+
+def _rasterise(svg: Path, png: Path) -> None:
+    """Render ``svg`` to ``png`` using the ``resvg`` command line tool."""
+    subprocess.run(["resvg", str(svg), str(png)], check=True)
+
+
+def build_sprite(symbols: List[str], out_base: Path) -> None:
+    tmpdir = Path(tempfile.mkdtemp())
+    images: List[tuple[str, Image.Image]] = []
+    for name in symbols:
+        svg = bauv_adapter.symbol_path(name)
+        png = tmpdir / f"{name}.png"
+        _rasterise(svg, png)
+        images.append((name, Image.open(png)))
+
+    width = sum(img.width for _, img in images)
+    height = max((img.height for _, img in images), default=0)
+    sprite = Image.new("RGBA", (width, height))
+    manifest: Dict[str, Dict[str, int]] = {}
+    x = 0
+    for name, img in images:
+        sprite.paste(img, (x, 0))
+        manifest[name] = {
+            "x": x,
+            "y": 0,
+            "width": img.width,
+            "height": img.height,
+            "pixelRatio": 1,
+        }
+        x += img.width
+
+    out_base.parent.mkdir(parents=True, exist_ok=True)
+    sprite.save(out_base.with_suffix(".png"))
+    with out_base.with_suffix(".json").open("w", encoding="utf-8") as fp:
+        json.dump(manifest, fp, indent=2, sort_keys=True)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("symbols", nargs="+", help="BAUV symbol names to rasterise")
+    p.add_argument(
+        "--out-base",
+        type=Path,
+        default=ROOT / "dist" / "sprites" / "bauv",
+        help="Output path prefix for sprite files",
+    )
+    args = p.parse_args()
+    build_sprite(args.symbols, args.out_base)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/VDR/third_party/__init__.py
+++ b/VDR/third_party/__init__.py
@@ -1,0 +1,1 @@
+"""Third party adapter utilities."""

--- a/VDR/third_party/bauv_adapter.py
+++ b/VDR/third_party/bauv_adapter.py
@@ -1,0 +1,49 @@
+"""Adapter utilities for accessing BAUV symbol and palette assets.
+
+This module exposes a small API expected by the vector style builder.  It
+provides helpers to enumerate available BAUV SVG symbols as well as loading
+colour palettes when present.  The adapter assumes that the BAUV source tree is
+vendored under ``VDR/BAUV`` with SVG symbols stored beneath ``src/public/svg``.
+
+The API is intentionally tiny; it merely returns paths and dictionaries leaving
+callers free to decide how the assets are consumed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterator, Tuple
+
+_BASE = Path(__file__).resolve().parents[1] / "BAUV" / "src" / "public"
+_SVG_DIR = _BASE / "svg"
+_PALETTE_FILE = _BASE / "palette.json"
+
+
+def iter_symbols() -> Iterator[Tuple[str, Path]]:
+    """Yield ``(name, path)`` pairs for all available BAUV SVG symbols."""
+    for path in sorted(_SVG_DIR.glob("*.svg")):
+        yield path.stem, path
+
+
+def symbol_path(name: str) -> Path:
+    """Return the filesystem path for ``name`` within the BAUV SVG set."""
+    path = _SVG_DIR / f"{name}.svg"
+    if not path.exists():
+        raise KeyError(f"Unknown BAUV symbol: {name}")
+    return path
+
+
+def load_palette() -> Dict[str, str]:
+    """Return a mapping of colour token -> ``#RRGGBB``.
+
+    BAUV currently ships a single palette stored as ``palette.json``.  If the
+    palette file is absent an empty mapping is returned.
+    """
+    if _PALETTE_FILE.exists():
+        with _PALETTE_FILE.open("r", encoding="utf-8") as fp:
+            return json.load(fp)
+    return {}
+
+
+__all__ = ["iter_symbols", "symbol_path", "load_palette"]


### PR DESCRIPTION
## Summary
- add BAUV adapter exposing symbol and palette APIs
- rasterize BAUV SVGs into MapLibre sprite sheet
- document BAUV assets and provenance

## Testing
- `pre-commit run --files VDR/third_party/bauv_adapter.py VDR/third_party/__init__.py VDR/server-styling/tools/bauv_sprite.py VDR/docs/bauv.md VDR/server-styling/dist/assets/bauv/PROVENANCE.txt`
- `python -m py_compile VDR/third_party/bauv_adapter.py VDR/server-styling/tools/bauv_sprite.py`
- `python VDR/server-styling/tools/bauv_sprite.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a1a865f890832aafc7b2430f348a37