### PR TITLE
Add glyph baking script and workflow

### DIFF
--- a/.github/workflows/vdr-glyphs.yml
+++ b/.github/workflows/vdr-glyphs.yml
@@ -1,0 +1,43 @@
+name: VDR Glyphs
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+  push:
+    paths:
+      - 'VDR/scripts/bake_glyphs.js'
+      - 'VDR/server-styling/fonts.lock'
+      - 'VDR/assets/fonts/**'
+      - '.github/workflows/vdr-glyphs.yml'
+
+jobs:
+  bake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install fontnik
+        run: npm install fontnik
+      - name: Fetch fonts
+        run: |
+          mkdir -p VDR/assets/fonts
+          jq -r '.fonts[] | "\(.url) \(.file) \(.sha256)"' VDR/server-styling/fonts.lock \
+            | while read url file sha; do
+                curl -L "$url" -o "VDR/assets/fonts/$file"
+                echo "$sha  VDR/assets/fonts/$file" | sha256sum -c -
+              done
+      - name: Bake glyphs
+        run: node VDR/scripts/bake_glyphs.js
+      - name: Upload glyphs artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: vdr-glyphs
+          path: glyphs
+      - name: Upload release assets
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: glyphs/**/*

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ VDR/chart-tiler/data/**/*.cog.json
 VDR/chart-tiler/registry.sqlite
 # Native cm93 converter artefacts
 VDR/tools/bin/
+
+# VDR fonts and generated glyphs
+VDR/assets/fonts/*.ttf
+glyphs/

--- a/VDR/README.md
+++ b/VDR/README.md
@@ -26,3 +26,9 @@ npm test --prefix VDR/web-client
 Artefacts are written under `chart-tiler/data/*` and `server-styling/dist/*`.
 
 See `docs/map_pipeline.md` for the full pipeline, database schema and testing matrix.
+
+## Fonts and glyphs
+Font binaries are intentionally excluded from version control. Fetch the fonts
+listed in `server-styling/fonts.lock` into `assets/fonts/` and run
+`node scripts/bake_glyphs.js` to produce `glyphs/{fontstack}/{range}.pbf`.
+Copy the glyphs to your deployment target as needed.

--- a/VDR/assets/fonts/PROVENANCE.txt
+++ b/VDR/assets/fonts/PROVENANCE.txt
@@ -1,0 +1,10 @@
+NotoSans-Regular.ttf
+Source: https://github.com/notofonts/noto-fonts/blob/main/hinted/ttf/NotoSans/NotoSans-Regular.ttf
+Version: 2.008
+License: SIL Open Font License 1.1
+
+To bake glyphs:
+1. Download the font from the source URL above and copy it here as `NotoSans-Regular.ttf`.
+2. Verify the download against the SHA256 in `VDR/server-styling/fonts.lock`.
+3. Run `node VDR/scripts/bake_glyphs.js` to generate PBFs in `glyphs/{fontstack}/{range}.pbf`.
+4. Copy those PBF files to your deployment location; do **not** commit fonts or glyphs to git.

--- a/VDR/scripts/bake_glyphs.js
+++ b/VDR/scripts/bake_glyphs.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Bake Mapbox glyph PBFs from the fonts listed in
+ * `VDR/server-styling/fonts.lock`. Download the referenced .ttf files and
+ * place them in `VDR/assets/fonts/` before running. The generated glyphs are
+ * written to `<repo>/glyphs/{fontstack}/{start}-{end}.pbf`.
+ */
+const fs = require('fs');
+const path = require('path');
+const fontnik = require('fontnik');
+
+async function rangeAsync(buf, start, end) {
+  return new Promise((resolve, reject) => {
+    fontnik.range({ font: buf, start, end }, (err, res) => {
+      if (err) reject(err); else resolve(res);
+    });
+  });
+}
+
+async function bake() {
+  const root = path.resolve(__dirname, '..');
+  const lockPath = path.join(root, 'server-styling', 'fonts.lock');
+  const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+  const glyphsDir = path.resolve(root, '..', 'glyphs');
+
+  for (const font of lock.fonts) {
+    const fontstack = path.basename(font.file, path.extname(font.file));
+    const ttfPath = path.join(root, 'assets', 'fonts', font.file);
+    const buf = fs.readFileSync(ttfPath);
+    for (let start = 0; start < 65536; start += 256) {
+      const end = start + 255;
+      const pbf = await rangeAsync(buf, start, end);
+      const outDir = path.join(glyphsDir, fontstack);
+      fs.mkdirSync(outDir, { recursive: true });
+      fs.writeFileSync(path.join(outDir, `${start}-${end}.pbf`), pbf);
+    }
+    console.log(`Baked glyphs for ${fontstack}`);
+  }
+}
+
+bake().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/VDR/server-styling/fonts.lock
+++ b/VDR/server-styling/fonts.lock
@@ -1,0 +1,10 @@
+{
+  "fonts": [
+    {
+      "file": "NotoSans-Regular.ttf",
+      "version": "2.008",
+      "url": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Regular.ttf",
+      "sha256": "b85c38ecea8a7cfb39c24e395a4007474fa5a4fc864f6ee33309eb4948d232d5"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- bake Mapbox glyph PBFs from pinned TTF fonts using node-fontnik
- document font provenance and locking, exclude binaries from git
- automate glyph baking and release upload via CI

## Testing
- `jq -r '.fonts[] | "\(.url) \(.file) \(.sha256)"' VDR/server-styling/fonts.lock | while read url file sha; do curl -L "$url" -o "VDR/assets/fonts/$file"; echo "$sha  VDR/assets/fonts/$file" | sha256sum -c -; done`
- `NODE_PATH=/tmp/glyph-test/node_modules node VDR/scripts/bake_glyphs.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1a8591fb0832a9e74b350cb235056