### PR TITLE
Add dev-up helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,14 @@ all: sprite style
 .PHONY: stage-assets
 stage-assets:
 >bash VDR/scripts/stage_assets_all.sh --force
+
+.PHONY: dev-up
+dev-up: stage-assets
+>python -m venv .venv
+>.venv/bin/pip install -r VDR/chart-tiler/requirements.txt
+>mkdir -p VDR/server-styling/dist/sprites
+>cp VDR/server-styling/dist/assets/s52/rastersymbols-day.png VDR/server-styling/dist/sprites/s52-day.png
+>.venv/bin/python VDR/server-styling/generate_sprite_json.py --chartsymbols VDR/server-styling/dist/assets/s52/chartsymbols.xml --output VDR/server-styling/dist/sprites/s52-day.json
+>mkdir -p VDR/server-styling/dist/glyphs
+>find VDR/BAUV/src/tileserver/fonts -name '*.pbf' -print0 | xargs -0 -I{} cp {} VDR/server-styling/dist/glyphs/ 2>/dev/null || true
+>.venv/bin/python VDR/chart-tiler/render_tile.py --help

--- a/VDR/docs/dev-up.md
+++ b/VDR/docs/dev-up.md
@@ -1,0 +1,22 @@
+# Dev Environment Setup
+
+`make dev-up` provisions a Python virtual environment and prepares local assets for the chart tiler.
+
+## Environment variables
+
+- `ENC_DIR` – override path to ENC datasets
+- `MBTILES_CACHE_SIZE` – in-memory MBTiles cache size
+- `REDIS_URL` / `REDIS_TTL` – optional Redis cache and TTL
+- `GEO_LRU_SIZE` – geospatial transform cache size
+- `IMPORT_API_ENABLED` – enable import endpoints
+
+## Ports
+
+- Chart tiler: `8000`
+- Web client: `3000`
+
+## Expected result
+
+Open `http://localhost:3000/` and verify the map loads:
+
+![Map loaded](map-loaded.svg)

--- a/VDR/docs/map-loaded.svg
+++ b/VDR/docs/map-loaded.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="#87CEEB"/>
+  <text x="200" y="150" text-anchor="middle" font-family="sans-serif" font-size="24" fill="#000">Map Loaded</text>
+</svg>


### PR DESCRIPTION
## Summary
- add `dev-up` target to bootstrap chart-tiler development assets and run smoke test
- document dev environment variables, ports and expected map output via SVG
- replace binary screenshot with text-based SVG

## Testing
- `python -m pre_commit run --files Makefile VDR/docs/dev-up.md VDR/docs/map-loaded.svg`
- `make dev-up`


------
https://chatgpt.com/codex/tasks/task_e_68a1a890e504832aa277daa3a8fe077a