### PR TITLE
Add CM93 schema and SCAMIN lookup

### DIFF
--- a/VDR/chart-tiler/README.md
+++ b/VDR/chart-tiler/README.md
@@ -50,6 +50,14 @@ Pragmas: `journal_mode=WAL`, `synchronous=NORMAL`, `busy_timeout=5000`. Backup v
 ## Backup/restore
 Use the `.backup` command above; restore by copying the backup over `registry.sqlite`.
 
+## Database migrations
+The CM93 tiler stores features in a PostGIS database. Apply migration scripts in
+`migrations/` to initialize or upgrade the schema:
+
+```
+psql $DATABASE_URL -v ON_ERROR_STOP=1 -f migrations/001_cm93_init.sql
+```
+
 ## Tests
 ```
 pytest VDR/chart-tiler/tests/test_convert_geotiff.py

--- a/VDR/chart-tiler/migrations/001_cm93_init.sql
+++ b/VDR/chart-tiler/migrations/001_cm93_init.sql
@@ -1,0 +1,98 @@
+-- CM93 initial database schema
+
+-- Cells covering CM93 chart tiles
+CREATE TABLE IF NOT EXISTS cm93_cells (
+    cell_id text PRIMARY KEY,
+    bounds geometry(Polygon, 4326)
+);
+
+-- Point features
+CREATE TABLE IF NOT EXISTS cm93_pts (
+    id bigserial PRIMARY KEY,
+    cell_id text NOT NULL REFERENCES cm93_cells(cell_id),
+    objl integer NOT NULL,
+    geom geometry(Point, 4326) NOT NULL,
+    attrs jsonb
+);
+CREATE INDEX idx_cm93_pts_geom ON cm93_pts USING GIST (geom);
+CREATE INDEX idx_cm93_pts_objl ON cm93_pts (objl);
+CREATE INDEX idx_cm93_pts_cell ON cm93_pts (cell_id);
+
+-- Line features
+CREATE TABLE IF NOT EXISTS cm93_ln (
+    id bigserial PRIMARY KEY,
+    cell_id text NOT NULL REFERENCES cm93_cells(cell_id),
+    objl integer NOT NULL,
+    geom geometry(MultiLineString, 4326) NOT NULL,
+    attrs jsonb
+);
+CREATE INDEX idx_cm93_ln_geom ON cm93_ln USING GIST (geom);
+CREATE INDEX idx_cm93_ln_objl ON cm93_ln (objl);
+CREATE INDEX idx_cm93_ln_cell ON cm93_ln (cell_id);
+
+-- Area features
+CREATE TABLE IF NOT EXISTS cm93_ar (
+    id bigserial PRIMARY KEY,
+    cell_id text NOT NULL REFERENCES cm93_cells(cell_id),
+    objl integer NOT NULL,
+    geom geometry(MultiPolygon, 4326) NOT NULL,
+    attrs jsonb
+);
+CREATE INDEX idx_cm93_ar_geom ON cm93_ar USING GIST (geom);
+CREATE INDEX idx_cm93_ar_objl ON cm93_ar (objl);
+CREATE INDEX idx_cm93_ar_cell ON cm93_ar (cell_id);
+
+-- Label points
+CREATE TABLE IF NOT EXISTS cm93_labels (
+    id bigserial PRIMARY KEY,
+    cell_id text NOT NULL REFERENCES cm93_cells(cell_id),
+    objl integer NOT NULL,
+    geom geometry(Point, 4326) NOT NULL,
+    text text,
+    attrs jsonb
+);
+CREATE INDEX idx_cm93_labels_geom ON cm93_labels USING GIST (geom);
+CREATE INDEX idx_cm93_labels_objl ON cm93_labels (objl);
+CREATE INDEX idx_cm93_labels_cell ON cm93_labels (cell_id);
+
+-- Light features
+CREATE TABLE IF NOT EXISTS cm93_lights (
+    id bigserial PRIMARY KEY,
+    cell_id text NOT NULL REFERENCES cm93_cells(cell_id),
+    pt geometry(Point, 4326) NOT NULL,
+    attrs jsonb
+);
+CREATE INDEX idx_cm93_lights_pt ON cm93_lights USING GIST (pt);
+CREATE INDEX idx_cm93_lights_cell ON cm93_lights (cell_id);
+
+-- Provenance metadata for imports
+CREATE TABLE IF NOT EXISTS import_provenance (
+    table_name text PRIMARY KEY,
+    src_path text,
+    src_sha256 text,
+    imported_at timestamptz DEFAULT now()
+);
+
+-- SCAMIN rules
+CREATE TABLE IF NOT EXISTS cm93_scamin (
+    objl integer PRIMARY KEY,
+    zmin integer NOT NULL,
+    zmax integer NOT NULL
+);
+
+INSERT INTO cm93_scamin (objl, zmin, zmax) VALUES
+    (71, 0, 16),   -- LNDARE
+    (42, 0, 16),   -- DEPARE
+    (43, 9, 16),   -- DEPCNT
+    (30, 0, 16),   -- COALNE
+    (129, 10, 16), -- SOUNDG
+    (159, 12, 16), -- WRECKS
+    (86, 12, 16);  -- OBSTRN
+
+CREATE OR REPLACE FUNCTION apply_scamin(objl int, z int)
+RETURNS boolean AS $$
+    SELECT COALESCE(
+        (SELECT $2 BETWEEN zmin AND zmax FROM cm93_scamin WHERE objl = $1),
+        TRUE
+    );
+$$ LANGUAGE SQL IMMUTABLE;


### PR DESCRIPTION
## Summary
- add initial CM93 schema with geometry tables, import provenance, and SCAMIN data
- implement apply_scamin SQL helper to respect SCAMIN ranges
- document running migrations

## Testing
- `pytest VDR/chart-tiler/tests/test_cm93_rules.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1b9a98178832a8442c45741abc5d4