### PR TITLE
Add CM93 offset conversion and DB loading

### DIFF
--- a/VDR/chart-tiler/cm93_importer.py
+++ b/VDR/chart-tiler/cm93_importer.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
+import json
 import logging
+import math
 import os
 import shutil
+import sqlite3
 import subprocess
 from pathlib import Path
 from typing import Dict, Iterable, List
@@ -51,34 +55,151 @@ def _load_offsets(path: Path) -> OffsetDict:
 
 
 def apply_offsets(features: Iterable[Dict[str, object]], offsets: OffsetDict) -> List[Dict[str, object]]:
+    """Apply regional meter offsets to features converting to degrees."""
     adjusted: List[Dict[str, object]] = []
     for feat in features:
         props = feat.get("properties", {})
         cell_id = str(props.get("cell_id", feat.get("cell_id")))
-        dx, dy = offsets.get(cell_id, (0.0, 0.0))
-        geom = translate(shape(feat["geometry"]), xoff=dx, yoff=dy)
+        dx_m, dy_m = offsets.get(cell_id, (0.0, 0.0))
+        geom = shape(feat["geometry"])
+        lat = geom.centroid.y
+        phi = math.radians(lat)
+        dx = dx_m / (111_320 * math.cos(phi)) if math.cos(phi) else 0.0
+        dy = dy_m / 111_320
+        geom = translate(geom, xoff=dx, yoff=dy)
         adj = dict(feat)
         adj["geometry"] = mapping(geom)
         adjusted.append(adj)
     return adjusted
 
 
+def stream_to_db(
+    features: Iterable[Dict[str, object]],
+    offsets: OffsetDict,
+    conn: sqlite3.Connection,
+    *,
+    bulk: bool = False,
+) -> None:
+    """Import adjusted features into ``cm93_*`` tables.
+
+    ``conn`` must provide the required tables.  Existing rows for affected
+    cells are removed before insertion so re-imports replace previous data.
+    """
+
+    adjusted = apply_offsets(features, offsets)
+
+    pts: List[tuple[int, str]] = []
+    ln: List[tuple[int, str]] = []
+    ar: List[tuple[int, str]] = []
+    labels: List[tuple[int, str, str]] = []
+    lights: List[tuple[int, str, str]] = []
+    cell_meta: Dict[int, Dict[str, object]] = {}
+
+    for feat in adjusted:
+        props = feat.get("properties", {})
+        cell_id = int(props.get("cell_id", feat.get("cell_id")))
+        geom = shape(feat["geometry"])
+        bbox = geom.bounds
+        entry = cell_meta.setdefault(
+            cell_id,
+            {
+                "bbox": list(bbox),
+                "offset": offsets.get(str(cell_id), (0.0, 0.0)),
+                "hash": hashlib.md5(),
+            },
+        )
+        b = entry["bbox"]
+        b[0] = min(b[0], bbox[0])
+        b[1] = min(b[1], bbox[1])
+        b[2] = max(b[2], bbox[2])
+        b[3] = max(b[3], bbox[3])
+        entry["hash"].update(json.dumps(props, sort_keys=True).encode())
+
+        wkt = geom.wkt
+        gtype = geom.geom_type
+        if gtype in {"Point", "MultiPoint"}:
+            pts.append((cell_id, wkt))
+        elif gtype in {"LineString", "MultiLineString"}:
+            ln.append((cell_id, wkt))
+        elif gtype in {"Polygon", "MultiPolygon"}:
+            ar.append((cell_id, wkt))
+
+        text = props.get("text")
+        if text:
+            labels.append((cell_id, str(text), wkt))
+        if props.get("objl") == "LIGHTS":
+            lights.append((cell_id, wkt, json.dumps(props, sort_keys=True)))
+
+    cell_ids = list(cell_meta.keys())
+    for cid in cell_ids:
+        conn.execute("DELETE FROM cm93_pts WHERE cell_id=?", (cid,))
+        conn.execute("DELETE FROM cm93_ln WHERE cell_id=?", (cid,))
+        conn.execute("DELETE FROM cm93_ar WHERE cell_id=?", (cid,))
+        conn.execute("DELETE FROM cm93_labels WHERE cell_id=?", (cid,))
+        conn.execute("DELETE FROM cm93_lights WHERE cell_id=?", (cid,))
+        conn.execute("DELETE FROM cm93_cells WHERE cell_id=?", (cid,))
+
+    if bulk:
+        conn.executemany("INSERT INTO cm93_pts(cell_id, geom) VALUES (?, ?)", pts)
+        conn.executemany("INSERT INTO cm93_ln(cell_id, geom) VALUES (?, ?)", ln)
+        conn.executemany("INSERT INTO cm93_ar(cell_id, geom) VALUES (?, ?)", ar)
+        conn.executemany("INSERT INTO cm93_labels(cell_id, text, geom) VALUES (?, ?, ?)", labels)
+        conn.executemany("INSERT INTO cm93_lights(cell_id, geom, attrs) VALUES (?, ?, ?)", lights)
+    else:
+        for row in pts:
+            conn.execute("INSERT INTO cm93_pts(cell_id, geom) VALUES (?, ?)", row)
+        for row in ln:
+            conn.execute("INSERT INTO cm93_ln(cell_id, geom) VALUES (?, ?)", row)
+        for row in ar:
+            conn.execute("INSERT INTO cm93_ar(cell_id, geom) VALUES (?, ?)", row)
+        for row in labels:
+            conn.execute("INSERT INTO cm93_labels(cell_id, text, geom) VALUES (?, ?, ?)", row)
+        for row in lights:
+            conn.execute("INSERT INTO cm93_lights(cell_id, geom, attrs) VALUES (?, ?, ?)", row)
+
+    for cid, meta in cell_meta.items():
+        bbox_str = ",".join(str(v) for v in meta["bbox"])
+        dx, dy = meta["offset"]
+        meta_hash = meta["hash"].hexdigest()
+        conn.execute(
+            "INSERT INTO cm93_cells(cell_id, bbox, offset_dx, offset_dy, meta_hash) VALUES (?,?,?,?,?)",
+            (cid, bbox_str, dx, dy, meta_hash),
+        )
+    conn.commit()
+
+
 def main() -> None:  # pragma: no cover - CLI helper
     parser = argparse.ArgumentParser(description="Import CM93 features with offsets")
     parser.add_argument("input", help="GeoJSON file of features")
     parser.add_argument("--offsets", required=True, help="CSV file with offsets")
-    parser.add_argument("--output", required=True, help="Output GeoJSON path")
+    parser.add_argument("--dsn", required=True, help="SQLite database DSN/path")
+    parser.add_argument("--bulk", action="store_true", help="Use bulk insertion")
+    parser.add_argument("--use-gdal", action="store_true", help="Use ogr2ogr for loading")
     args = parser.parse_args()
 
-    import json
-
-    features = json.loads(Path(args.input).read_text())
+    features = json.loads(Path(args.input).read_text())["features"]
     offsets = _load_offsets(Path(args.offsets))
-    adjusted = apply_offsets(features["features"], offsets)
-    Path(args.output).write_text(json.dumps({"type": "FeatureCollection", "features": adjusted}))
+    conn = sqlite3.connect(args.dsn)
+    try:
+        if args.use_gdal:
+            subprocess.check_call(
+                [
+                    "ogr2ogr",
+                    "-f",
+                    "SQLite",
+                    args.dsn,
+                    args.input,
+                    "-nln",
+                    "cm93_ar",
+                ]
+            )
+        else:
+            stream_to_db(features, offsets, conn, bulk=args.bulk)
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":  # pragma: no cover
     main()
 
-__all__ = ["apply_offsets", "run_cm93_convert"]
+__all__ = ["apply_offsets", "run_cm93_convert", "stream_to_db"]

--- a/VDR/chart-tiler/scripts/validate_offsets.py
+++ b/VDR/chart-tiler/scripts/validate_offsets.py
@@ -8,6 +8,7 @@ from typing import Dict, Iterable, List
 
 from shapely.geometry import shape
 from shapely.affinity import translate
+import math
 
 
 def _load_offsets(path: Path) -> Dict[str, tuple[float, float]]:
@@ -19,7 +20,12 @@ def _load_offsets(path: Path) -> Dict[str, tuple[float, float]]:
     return offs
 
 
-def _apply(geom, dx: float, dy: float):
+def _apply(geom, dx_m: float, dy_m: float):
+    """Translate ``geom`` by meter offsets converted to degrees."""
+    lat = geom.centroid.y
+    phi = math.radians(lat)
+    dx = dx_m / (111_320 * math.cos(phi)) if math.cos(phi) else 0.0
+    dy = dy_m / 111_320
     return translate(geom, xoff=dx, yoff=dy)
 
 

--- a/VDR/chart-tiler/tests/fixtures/cm93/offsets.csv
+++ b/VDR/chart-tiler/tests/fixtures/cm93/offsets.csv
@@ -1,3 +1,3 @@
 cell_id,region_id,offset_dx_m,offset_dy_m
-1,1,-0.01,0
+1,1,-1113.1576,0
 2,1,0,0

--- a/VDR/chart-tiler/tests/test_cm93_db.py
+++ b/VDR/chart-tiler/tests/test_cm93_db.py
@@ -1,0 +1,50 @@
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+
+BASE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BASE))
+sys.path.insert(0, str(BASE / "scripts"))
+
+from cm93_importer import stream_to_db  # type: ignore
+from validate_offsets import _load_offsets  # type: ignore
+
+FIX = Path(__file__).parent / "fixtures" / "cm93"
+
+
+def _conn():
+    c = sqlite3.connect(":memory:")
+    c.execute("CREATE TABLE cm93_pts(cell_id INTEGER, geom TEXT)")
+    c.execute("CREATE TABLE cm93_ln(cell_id INTEGER, geom TEXT)")
+    c.execute("CREATE TABLE cm93_ar(cell_id INTEGER, geom TEXT)")
+    c.execute("CREATE TABLE cm93_labels(cell_id INTEGER, text TEXT, geom TEXT)")
+    c.execute("CREATE TABLE cm93_lights(cell_id INTEGER, geom TEXT, attrs TEXT)")
+    c.execute(
+        "CREATE TABLE cm93_cells(cell_id INTEGER PRIMARY KEY, bbox TEXT, offset_dx REAL, offset_dy REAL, meta_hash TEXT)"
+    )
+    return c
+
+
+def _features():
+    data = json.loads((FIX / "cells.geojson").read_text())
+    return data["features"]
+
+
+def test_stream_to_db_reimport():
+    feats = _features()
+    offsets = _load_offsets(FIX / "offsets.csv")
+    conn = _conn()
+    stream_to_db(feats, offsets, conn, bulk=True)
+    # importing again should replace data rather than duplicate
+    stream_to_db(feats, offsets, conn, bulk=True)
+    cur = conn.execute("SELECT COUNT(*) FROM cm93_cells")
+    assert cur.fetchone()[0] == 2
+    cur = conn.execute("SELECT COUNT(*) FROM cm93_ar")
+    assert cur.fetchone()[0] == 2
+    cur = conn.execute("SELECT bbox, offset_dx FROM cm93_cells WHERE cell_id=1")
+    bbox, dx = cur.fetchone()
+    nums = list(map(float, bbox.split(",")))
+    assert all(abs(a - b) < 1e-6 for a, b in zip(nums, [0.0, 0.0, 1.0, 1.0]))
+    assert abs(dx + 1113.1576) < 1e-4

--- a/VDR/chart-tiler/tests/test_offsets.py
+++ b/VDR/chart-tiler/tests/test_offsets.py
@@ -21,9 +21,27 @@ def test_apply_offsets():
     feats = load_features()
     offsets = _load_offsets(FIX / "offsets.csv")
     adj = apply_offsets(feats, offsets)
-    # first feature should shift left by 0.01
+    # first feature should shift left by ~0.01 degrees (1113.2 m at equator)
     x0 = adj[0]["geometry"]["coordinates"][0][0][0]
     assert abs(x0 - 0.0) < 1e-6
+
+
+def test_apply_offsets_high_lat():
+    feats = [
+        {
+            "type": "Feature",
+            "properties": {"cell_id": 9},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[0, 59.5], [0, 60.5], [1, 60.5], [1, 59.5], [0, 59.5]]],
+            },
+        }
+    ]
+    offsets = {"9": (1113.2, 0.0)}
+    adj = apply_offsets(feats, offsets)
+    x0 = adj[0]["geometry"]["coordinates"][0][0][0]
+    # At latitude 60°, 1113.2 m ≈ 0.02°
+    assert abs(x0 - 0.02) < 1e-6
 
 
 def test_validate_offsets():


### PR DESCRIPTION
## Summary
- convert meter offsets to degrees in CM93 importer and apply during DB streaming
- add streaming importer that loads features by geometry into cm93 tables and records cell metadata
- add tests for meter-to-degree conversion and database insert replacement

## Testing
- `pre-commit run --files VDR/chart-tiler/cm93_importer.py VDR/chart-tiler/scripts/validate_offsets.py VDR/chart-tiler/tests/fixtures/cm93/offsets.csv VDR/chart-tiler/tests/test_offsets.py VDR/chart-tiler/tests/test_cm93_db.py`
- `pytest VDR/chart-tiler/tests/test_offsets.py VDR/chart-tiler/tests/test_cm93_db.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1b9af23d8832ab8d087b8676d9cb1