### PR TITLE
Add SENC ingestion and registry support

### DIFF
--- a/VDR/chart-tiler/README.md
+++ b/VDR/chart-tiler/README.md
@@ -15,6 +15,13 @@ GET /metrics
 GET /healthz
 ```
 
+## SENC ingestion
+Use `opencpn_ingest.py` to build OpenCPN `.senc` caches and register them:
+
+```
+python opencpn_ingest.py SOURCE DATASET_ID
+```
+
 ## Cache keys
 Tiles are cached by `fmt:ds:z/x/y:safety,shallow,deep`. Set `MBTILES_CACHE_SIZE` to tune the in‑memory LRU.
 
@@ -29,6 +36,9 @@ CREATE TABLE IF NOT EXISTS charts (
   bbox TEXT,
   minzoom INTEGER,
   maxzoom INTEGER,
+  scale_min INTEGER,
+  scale_max INTEGER,
+  senc_path TEXT,
   updated_at TEXT,
   tags TEXT,
   status TEXT

--- a/VDR/chart-tiler/opencpn_ingest.py
+++ b/VDR/chart-tiler/opencpn_ingest.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Build an OpenCPN SENC cache and register it.
+
+Usage
+-----
+>>> python opencpn_ingest.py SOURCE DATASET_ID
+
+``SOURCE`` is the path to an ENC dataset.  The resulting ``DATASET_ID`` is
+used for the output ``.senc`` cache and registry entry.
+"""
+
+import json
+from pathlib import Path
+
+from opencpn_bridge import build_senc, query_features
+from registry import get_registry
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets" / "senc"
+
+
+def ingest(source: Path, dataset_id: str) -> Path:
+    """Create SENC cache from *source* and register it."""
+
+    ASSETS_DIR.mkdir(parents=True, exist_ok=True)
+    senc_path = ASSETS_DIR / f"{dataset_id}.senc"
+    build_senc(str(source), str(senc_path))
+    info = query_features(str(senc_path))
+    bbox = info.get("bbox", [0, 0, 0, 0])
+    scale_min = int(info.get("scale_min", 0))
+    scale_max = int(info.get("scale_max", 0))
+    meta = {
+        "id": dataset_id,
+        "bbox": bbox,
+        "scale_min": scale_min,
+        "scale_max": scale_max,
+    }
+    meta_path = senc_path.with_name(f"{senc_path.stem}.senc.json")
+    meta_path.write_text(json.dumps(meta))
+    registry = get_registry()
+    registry.register_senc(meta_path, senc_path)
+    return senc_path
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI convenience
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path, help="Path to ENC source")
+    parser.add_argument("dataset_id", type=str, help="Dataset identifier")
+    args = parser.parse_args()
+    ingest(args.source, args.dataset_id)


### PR DESCRIPTION
## Summary
- add `opencpn_ingest.py` script to build and register SENC caches
- extend registry with SENC metadata fields and scanning support
- document SENC ingestion workflow and new registry columns

## Testing
- `pytest VDR/chart-tiler/tests/test_convert_geotiff.py`
- `pytest VDR/chart-tiler/tests/test_registry_scan.py`
- `pytest VDR/chart-tiler/tests/test_tiles_geotiff.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1e66e10d4832a8d9839b9a10dfd22