### PR TITLE
Add bridge and tileserver tests

### DIFF
--- a/VDR/pytest.ini
+++ b/VDR/pytest.ini
@@ -3,3 +3,6 @@ DJANGO_SETTINGS_MODULE = tests.minimal_settings
 testpaths =
     tests
     chart-tiler/tests
+markers =
+    bridge: requires opencpn bridge library
+    tileserver: tileserver integration tests

--- a/VDR/tests/test_opencpn_bridge.py
+++ b/VDR/tests/test_opencpn_bridge.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+pytestmark = pytest.mark.bridge
+
+# Skip if bridge is not available
+opencpn_bridge = pytest.importorskip("opencpn_bridge")
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "testdata"
+
+
+@pytest.fixture
+def senc_file(tmp_path: Path) -> Path:
+    """Build a temporary SENC file from the sample dataset."""
+    src = DATA_DIR / "sample.000"
+    if not src.exists():
+        pytest.skip("sample dataset missing")
+    dest = tmp_path / "sample.senc"
+    opencpn_bridge.build_senc(str(src), str(dest))  # type: ignore[attr-defined]
+    return dest
+
+
+def test_build_senc_creates_output(senc_file: Path) -> None:
+    assert senc_file.exists()
+    assert senc_file.stat().st_size > 0
+
+
+def test_query_features_returns_features(senc_file: Path) -> None:
+    bbox = (-180.0, -90.0, 180.0, 90.0)
+    features = list(opencpn_bridge.query_features(str(senc_file), bbox))  # type: ignore[attr-defined]
+    assert features

--- a/VDR/tests/test_tileserver_senc.py
+++ b/VDR/tests/test_tileserver_senc.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "chart-tiler"
+sys.path.insert(0, str(ROOT))
+
+import mapbox_vector_tile
+import pytest
+from fastapi.testclient import TestClient
+from datasource_stub import features_for_tile as _base_features
+import tileserver  # noqa: E402
+
+pytestmark = pytest.mark.tileserver
+
+client = TestClient(tileserver.app)
+
+
+def _decode_mvt(data: bytes):
+    return mapbox_vector_tile.decode(data)
+
+
+@pytest.fixture(autouse=True)
+def _light_feature(monkeypatch):
+    def _features(bbox, z, x, y):
+        for f in _base_features(bbox, z, x, y):
+            yield f
+        minx, miny, maxx, maxy = bbox
+        midx = (minx + maxx) / 2.0
+        midy = (miny + maxy) / 2.0
+        yield {
+            "geometry": {"type": "Point", "coordinates": [midx, midy]},
+            "properties": {"OBJL": "LIGHTS"},
+        }
+
+    monkeypatch.setattr(tileserver, "features_for_tile", _features)
+    tileserver._render_mvt.cache_clear()
+
+
+def test_cm93_core_tile_non_empty() -> None:
+    resp = client.get("/tiles/cm93-core/14/0/0.pbf")
+    assert resp.status_code == 200
+    assert resp.content
+    tile = _decode_mvt(resp.content)
+    assert tile["features"]["features"]
+
+
+def test_cm93_label_tile_non_empty() -> None:
+    resp = client.get("/tiles/cm93-label/14/0/0.pbf")
+    assert resp.status_code == 200
+    assert resp.content
+    tile = _decode_mvt(resp.content)
+    assert tile["features"]["features"]


### PR DESCRIPTION
## Summary
- add tests for opencpn_bridge build_senc and query_features
- add FastAPI TestClient tests for tileserver MVT output
- declare bridge and tileserver markers in pytest.ini

## Testing
- `python -m pytest VDR/tests/test_tileserver_senc.py VDR/tests/test_opencpn_bridge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1e6747450832aa377caab7c35d958