### PR TITLE
Add stub OpenCPN bridge with Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2433,6 +2433,13 @@ if (NOT SKIP_PLUGINS)
 endif ()
 
 #
+# Python bridge exposing minimal chart stub.
+#
+option(OPB_STUB_ONLY "Build only the stub implementation of the OpenCPN bridge" ON)
+option(OPB_WITH_OCPN_MINI "Enable vendor OCPN mini bridge code" OFF)
+add_subdirectory(opencpn_bridge/cpp)
+
+#
 # Prepare CPACK configuration
 #
 if (WIN32)

--- a/opencpn_bridge/cpp/CMakeLists.txt
+++ b/opencpn_bridge/cpp/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.15)
+project(opencpn_bridge_stub LANGUAGES CXX)
+
+include(FetchContent)
+FetchContent_Declare(
+  pybind11
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
+)
+FetchContent_MakeAvailable(pybind11)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# build the python module into the adjacent py/ directory
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../py)
+
+set(SOURCES
+  bridge.cpp
+)
+
+if(OPB_STUB_ONLY)
+  list(APPEND SOURCES
+    stub/stub.cpp
+  )
+endif()
+
+pybind11_add_module(opencpn_bridge MODULE ${SOURCES})
+
+# placeholder for future vendor code option
+if(OPB_WITH_OCPN_MINI)
+  message(STATUS "OPB_WITH_OCPN_MINI is not implemented; building stub only")
+endif()
+

--- a/opencpn_bridge/cpp/bridge.cpp
+++ b/opencpn_bridge/cpp/bridge.cpp
@@ -1,0 +1,29 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+// Declarations of the stub functions located in stub/.
+std::string build_senc(const std::string &chart_path,
+                       const std::string &output_dir);
+std::string query_tile_mvt(const std::string &senc_root,
+                           int z, int x, int y);
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(opencpn_bridge, m) {
+  m.doc() = "Python bindings for the OpenCPN stub bridge";
+
+  m.def("build_senc", &build_senc, py::arg("chart_path"),
+        py::arg("output_dir"),
+        "Build a stub SENC and write a dummy provenance.json, returning the output path");
+
+  m.def(
+      "query_tile_mvt",
+      [](const std::string &senc_root, int z, int x, int y) {
+        auto data = query_tile_mvt(senc_root, z, x, y);
+        return py::bytes(data);
+      },
+      py::arg("senc_root"), py::arg("z"), py::arg("x"), py::arg("y"),
+      "Return an empty Mapbox Vector Tile for the requested coordinates");
+}
+

--- a/opencpn_bridge/cpp/stub/stub.cpp
+++ b/opencpn_bridge/cpp/stub/stub.cpp
@@ -1,0 +1,19 @@
+#include <fstream>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+std::string build_senc(const std::string &chart_path, const std::string &output_dir) {
+    (void)chart_path; // unused in stub
+    fs::create_directories(output_dir);
+    std::ofstream(output_dir + "/provenance.json") << "{\"stub\": true}\n";
+    return output_dir;
+}
+
+std::string query_tile_mvt(const std::string &senc_root, int z, int x, int y) {
+    (void)senc_root; (void)z; (void)x; (void)y;
+    // Return an empty protobuf tile
+    return std::string();
+}
+

--- a/opencpn_bridge/py/__init__.py
+++ b/opencpn_bridge/py/__init__.py
@@ -1,0 +1,5 @@
+"""OpenCPN bridge stub Python package."""
+from .bridge import build_senc, query_tile_mvt
+
+__all__ = ["build_senc", "query_tile_mvt"]
+

--- a/opencpn_bridge/py/bridge.py
+++ b/opencpn_bridge/py/bridge.py
@@ -1,0 +1,15 @@
+"""Python wrappers around the stub OpenCPN bridge."""
+from __future__ import annotations
+
+from . import opencpn_bridge as _bridge
+
+
+def build_senc(chart_path: str, output_dir: str) -> str:
+    """Create a stub SENC and return the output directory."""
+    return _bridge.build_senc(chart_path, output_dir)
+
+
+def query_tile_mvt(senc_root: str, z: int, x: int, y: int) -> bytes:
+    """Return an empty Mapbox Vector Tile for the given coordinates."""
+    return _bridge.query_tile_mvt(senc_root, z, x, y)
+


### PR DESCRIPTION
## Summary
- add CMake options and build hooks for a stub opencpn_bridge module
- implement stub bridge in C++ with pybind11 and Python wrapper

## Testing
- `python -m py_compile opencpn_bridge/py/bridge.py opencpn_bridge/py/__init__.py`
- `cmake -S opencpn_bridge/cpp -B opencpn_bridge/cpp/build`
- `cmake --build opencpn_bridge/cpp/build`


------
https://chatgpt.com/codex/tasks/task_e_68a2086344c8832aa835c04a85e9349e