### PR TITLE
Add S-52 asset staging script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ VDR/tools/bin/
 # VDR fonts and generated glyphs
 VDR/assets/fonts/*.ttf
 glyphs/
+opencpn_bridge/dist/assets/s52/*
+!opencpn_bridge/dist/assets/s52/assets.manifest.json
+!opencpn_bridge/dist/assets/s52/PROVENANCE.txt

--- a/opencpn_bridge/dist/assets/s52/PROVENANCE.txt
+++ b/opencpn_bridge/dist/assets/s52/PROVENANCE.txt
@@ -1,0 +1,2 @@
+Upstream: unknown
+Commit: 867b06aaaf6152cad5706cb87a8835708d0645e5

--- a/opencpn_bridge/dist/assets/s52/assets.manifest.json
+++ b/opencpn_bridge/dist/assets/s52/assets.manifest.json
@@ -1,0 +1,8 @@
+{
+  "S52RAZDS.RLE": "79c122508612a00c4d8d133a415660ed896f86234175387967618351bed7086b",
+  "attdecode.csv": "141f04b1a0a5c6f7ff4dde9e486a866d240c758c13ac05a8799bd481ebfa4252",
+  "chartsymbols.xml": "51f3c5aa64f80de2c2952be3c3b3d6e61977cea9d92408296201ff198450a1e8",
+  "rastersymbols-day.png": "ee1020a8b94b312faba8c146974e49147d280e5ef3cc13f3cd688bbfd54dde0c",
+  "s57attributes.csv": "61c3fc9db5cfbc0aaefdcfb17474d64b56db7e7be6238974f6f1a11680a6b2c7",
+  "s57objectclasses.csv": "5e823ae9b78fa8f976b16231b96548215fb020fb3f83751748c7e767b9ea232a"
+}

--- a/opencpn_bridge/tools/stage_s52_assets.py
+++ b/opencpn_bridge/tools/stage_s52_assets.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Stage OpenCPN S-52/S-57 assets for opencpn_bridge."""
+
+from __future__ import annotations
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict
+
+ASSETS = [
+    "chartsymbols.xml",
+    "rastersymbols-day.png",
+    "S52RAZDS.RLE",
+    "s57objectclasses.csv",
+    "s57attributes.csv",
+    "attdecode.csv",
+]
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    src = repo_root / "data" / "s57data"
+    dest = repo_root / "opencpn_bridge" / "dist" / "assets" / "s52"
+    dest.mkdir(parents=True, exist_ok=True)
+
+    missing = [name for name in ASSETS if not (src / name).is_file()]
+    if missing:
+        raise FileNotFoundError("missing assets: " + ", ".join(sorted(missing)))
+
+    manifest: dict[str, str] = {}
+    for name in ASSETS:
+        shutil.copy2(src / name, dest / name)
+        manifest[name] = _sha256(dest / name)
+
+    (dest / "assets.manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    try:
+        url = subprocess.check_output(
+            ["git", "config", "--get", "remote.origin.url"], text=True
+        ).strip()
+    except subprocess.CalledProcessError:
+        url = "unknown"
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    (dest / "PROVENANCE.txt").write_text(
+        f"Upstream: {url}\nCommit: {commit}\n", encoding="utf-8"
+    )
+
+    print(f"Staged {len(manifest)} assets to {dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- stage OpenCPN S-52 assets for opencpn_bridge with Python script
- track asset manifest and provenance while ignoring generated files

## Testing
- `pre-commit run --files .gitignore opencpn_bridge/tools/stage_s52_assets.py opencpn_bridge/dist/assets/s52/assets.manifest.json opencpn_bridge/dist/assets/s52/PROVENANCE.txt`

------
https://chatgpt.com/codex/tasks/task_e_68a20870f49c832ab20b2129dd300556