### PR TITLE
Add dataset ingestion utility and registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ tags
 VDR/chart-tiler/data/**/*.cog.tif
 VDR/chart-tiler/data/**/*.cog.json
 VDR/chart-tiler/registry.sqlite
+opencpn_bridge/registry/registry.sqlite
+opencpn_bridge/.cache/
 # Native cm93 converter artefacts
 VDR/tools/bin/
 

--- a/opencpn_bridge/py/__init__.py
+++ b/opencpn_bridge/py/__init__.py
@@ -1,0 +1,3 @@
+from .ingest import ingest_dataset
+
+__all__ = ["ingest_dataset"]

--- a/opencpn_bridge/py/ingest.py
+++ b/opencpn_bridge/py/ingest.py
@@ -1,0 +1,69 @@
+import json
+import shutil
+import sqlite3
+from pathlib import Path
+
+
+def ingest_dataset(dataset_id: str, src_root: str, dataset_type: str) -> None:
+    """Ingest a dataset into the SENC cache and registry."""
+    root = Path(__file__).resolve().parent.parent
+    src_root = Path(src_root)
+    senc_root = root / ".cache" / "senc" / dataset_id
+    senc_root.mkdir(parents=True, exist_ok=True)
+
+    for item in src_root.iterdir():
+        dest = senc_root / item.name
+        if item.is_dir():
+            shutil.copytree(item, dest, dirs_exist_ok=True)
+        else:
+            shutil.copy2(item, dest)
+
+    provenance_path = senc_root / "provenance.json"
+    bounds = minzoom = maxzoom = None
+    if provenance_path.exists():
+        with provenance_path.open() as f:
+            data = json.load(f)
+        bounds = data.get("bounds")
+        minzoom = data.get("minzoom")
+        maxzoom = data.get("maxzoom")
+
+    registry_path = root / "registry" / "registry.sqlite"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(registry_path)
+    with conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS datasets(
+                id TEXT PRIMARY KEY,
+                type TEXT,
+                bounds TEXT,
+                minzoom INTEGER,
+                maxzoom INTEGER,
+                senc_path TEXT,
+                provenance_path TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO datasets(id, type, bounds, minzoom, maxzoom, senc_path, provenance_path)
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                type=excluded.type,
+                bounds=excluded.bounds,
+                minzoom=excluded.minzoom,
+                maxzoom=excluded.maxzoom,
+                senc_path=excluded.senc_path,
+                provenance_path=excluded.provenance_path
+            """,
+            (
+                dataset_id,
+                dataset_type,
+                json.dumps(bounds) if bounds is not None else None,
+                minzoom,
+                maxzoom,
+                str(senc_root),
+                str(provenance_path),
+            ),
+        )
+    conn.close()

--- a/opencpn_bridge/py/tests/test_ingest.py
+++ b/opencpn_bridge/py/tests/test_ingest.py
@@ -1,0 +1,66 @@
+import json
+import sqlite3
+import shutil
+from pathlib import Path
+import unittest
+
+from opencpn_bridge.py.ingest import ingest_dataset
+
+
+class IngestTests(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(__file__).resolve().parents[2]
+        self.registry = self.root / "registry" / "registry.sqlite"
+        if self.registry.exists():
+            conn = sqlite3.connect(self.registry)
+            conn.execute("DELETE FROM datasets")
+            conn.commit()
+            conn.close()
+        else:
+            self.registry.parent.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        cache = self.root / ".cache"
+        if cache.exists():
+            shutil.rmtree(cache)
+        if self.registry.exists():
+            conn = sqlite3.connect(self.registry)
+            conn.execute("DELETE FROM datasets")
+            conn.commit()
+            conn.close()
+
+    def test_idempotent_ingest(self):
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmp:
+            src = Path(tmp)
+            meta = {"bounds": [0, 0, 1, 1], "minzoom": 0, "maxzoom": 10}
+            (src / "provenance.json").write_text(json.dumps(meta))
+            (src / "data.txt").write_text("data")
+
+            ingest_dataset("ds1", src, "test")
+
+            cache = self.root / ".cache" / "senc" / "ds1"
+            self.assertTrue((cache / "data.txt").exists())
+
+            conn = sqlite3.connect(self.registry)
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM datasets WHERE id=?", ("ds1",))
+            self.assertEqual(cur.fetchone()[0], 1)
+            conn.close()
+
+            meta["minzoom"] = 1
+            (src / "provenance.json").write_text(json.dumps(meta))
+            ingest_dataset("ds1", src, "test")
+
+            conn = sqlite3.connect(self.registry)
+            cur = conn.cursor()
+            cur.execute("SELECT minzoom FROM datasets WHERE id=?", ("ds1",))
+            self.assertEqual(cur.fetchone()[0], 1)
+            cur.execute("SELECT COUNT(*) FROM datasets")
+            self.assertEqual(cur.fetchone()[0], 1)
+            conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create dataset ingestion routine that initializes registry database on first use
- ignore generated registry and cache files to avoid committing binaries
- update tests to work with on-demand registry creation

## Testing
- `python -m unittest opencpn_bridge.py.tests.test_ingest -v`


------
https://chatgpt.com/codex/tasks/task_e_68a2087b03ac832aa1d3ca74e32e0cb7