### PR TITLE
docs: add bridge documentation

### DIFF
--- a/VDR/opencpn_bridge/docs/README.md
+++ b/VDR/opencpn_bridge/docs/README.md
@@ -1,0 +1,33 @@
+# OpenCPN Bridge
+
+This module exposes a tiny slice of the OpenCPN chart stack to Python.  It is
+used to experiment with SENC generation and vector tile queries without the
+full application.
+
+## Quickstart
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+The build emits a Python extension that can be driven from the CLI.  During
+local testing point the CLI at the staging tileserver and registry:
+
+```bash
+./bridge_cli --registry https://registry.example/staging \
+             --tileserver https://tiles.staging.example
+```
+
+Example Python session:
+
+```python
+from opencpn_bridge import build_senc, query_tile_mvt
+
+handle = build_senc("/charts/demo.000")
+tile = query_tile_mvt(handle, 0, 0, 0)
+print(len(tile))
+```
+
+Release builds are pushed to the container registry and deployed alongside the
+production tileserver.

--- a/VDR/opencpn_bridge/docs/api_contracts.md
+++ b/VDR/opencpn_bridge/docs/api_contracts.md
@@ -1,0 +1,23 @@
+# API Contracts
+
+The bridge aims to serve tiles over HTTP and through a small CLI.  Stub
+functions provide the core operations:
+
+```python
+def build_senc(path: str) -> str:
+    """Create a SENC and return a handle used by the tileserver."""
+    ...
+
+
+def query_tile_mvt(handle: str, z: int, x: int, y: int) -> bytes:
+    """Return an MVT tile for the given chart handle."""
+    ...
+```
+
+Proposed tile endpoints:
+
+- `POST /v1/charts` – runs `build_senc` and stages the result in the registry.
+- `GET /tiles/{handle}/{z}/{x}/{y}.mvt` – calls `query_tile_mvt`.
+
+The CLI wraps these calls and defaults to the staging tileserver.  Once tiles
+look correct they can be pushed to the registry and served from production.

--- a/VDR/opencpn_bridge/docs/bridge_build.md
+++ b/VDR/opencpn_bridge/docs/bridge_build.md
@@ -1,0 +1,18 @@
+# Bridge Build
+
+The bridge uses CMake and pybind11 to produce a small extension module.
+Typical options:
+
+- `-DCMAKE_BUILD_TYPE=Debug` – development builds for staging and CLI tests.
+- `-DCMAKE_BUILD_TYPE=Release` – optimized builds published to the registry.
+- `-DBUILD_SHARED_LIBS=ON` – emit a shared library instead of a module.
+
+Example release build:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+```
+
+After compiling, use the CLI against the staging tileserver to verify output
+before pushing images to the registry.


### PR DESCRIPTION
## Summary
- document bridge goals and quickstart
- add build options and API contract docs referencing staging, registry, CLI, and tileserver

## Testing
- `pre-commit run --files VDR/opencpn_bridge/docs/README.md VDR/opencpn_bridge/docs/bridge_build.md VDR/opencpn_bridge/docs/api_contracts.md`

------
https://chatgpt.com/codex/tasks/task_e_68a20892cc78832a8ecf207f06021966