### PR TITLE
Enhance SENC ingestion with provenance and metadata

### DIFF
--- a/VDR/chart-tiler/opencpn_ingest.py
+++ b/VDR/chart-tiler/opencpn_ingest.py
@@ -11,6 +11,9 @@ used for the output ``.senc`` cache and registry entry.
 """
 
 import json
+import math
+import subprocess
+from datetime import datetime
 from pathlib import Path
 
 from opencpn_bridge import build_senc, query_features
@@ -19,26 +22,55 @@ from registry import get_registry
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets" / "senc"
 
 
+def _scale_to_zoom(scale: int) -> int:
+    if scale <= 0:
+        return 0
+    return max(0, int(round(math.log2(559082264.028 / float(scale)))))
+
+
+def _write_provenance(dataset_root: Path, path: Path) -> None:
+    commit = (
+        subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=Path(__file__).resolve().parents[2])
+        .decode()
+        .strip()
+    )
+    data = {
+        "dataset_root": str(dataset_root),
+        "built": datetime.utcnow().isoformat() + "Z",
+        "commit": commit,
+    }
+    path.write_text(json.dumps(data))
+
+
 def ingest(source: Path, dataset_id: str) -> Path:
     """Create SENC cache from *source* and register it."""
 
     ASSETS_DIR.mkdir(parents=True, exist_ok=True)
     senc_path = ASSETS_DIR / f"{dataset_id}.senc"
-    build_senc(str(source), str(senc_path))
+    provenance_path = ASSETS_DIR / f"{dataset_id}.provenance.json"
+    try:
+        build_senc(str(source), str(senc_path), provenance_path=str(provenance_path))
+    except TypeError:  # pragma: no cover - fallback for older bridges
+        build_senc(str(source), str(senc_path))
+    _write_provenance(source, provenance_path)
     info = query_features(str(senc_path))
     bbox = info.get("bbox", [0, 0, 0, 0])
     scale_min = int(info.get("scale_min", 0))
     scale_max = int(info.get("scale_max", 0))
+    minzoom = _scale_to_zoom(scale_max)
+    maxzoom = _scale_to_zoom(scale_min)
     meta = {
         "id": dataset_id,
         "bbox": bbox,
         "scale_min": scale_min,
         "scale_max": scale_max,
+        "minzoom": minzoom,
+        "maxzoom": maxzoom,
     }
     meta_path = senc_path.with_name(f"{senc_path.stem}.senc.json")
     meta_path.write_text(json.dumps(meta))
     registry = get_registry()
-    registry.register_senc(meta_path, senc_path)
+    registry.register_senc(meta_path, senc_path, provenance_path)
     return senc_path
 
 

--- a/VDR/chart-tiler/tests/test_senc_registry.py
+++ b/VDR/chart-tiler/tests/test_senc_registry.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import registry
+
+
+def _stub_bridge(tmp_path: Path) -> None:
+    mod = types.ModuleType("opencpn_bridge")
+
+    def build_senc(src: str, dst: str, provenance_path: str | None = None) -> None:
+        Path(dst).write_text("senc")
+        if provenance_path:
+            Path(provenance_path).write_text(json.dumps({}))
+
+    def query_features(path: str) -> dict[str, object]:
+        return {"bbox": [0.0, 0.0, 1.0, 1.0], "scale_min": 1000, "scale_max": 2000}
+
+    mod.build_senc = build_senc  # type: ignore[attr-defined]
+    mod.query_features = query_features  # type: ignore[attr-defined]
+    sys.modules["opencpn_bridge"] = mod
+
+
+def test_registry_entry_after_ingest(tmp_path, monkeypatch):
+    _stub_bridge(tmp_path)
+    monkeypatch.setattr(registry, "DB_PATH", tmp_path / "registry.sqlite")
+    registry._registry = None
+
+    import opencpn_ingest
+
+    monkeypatch.setattr(opencpn_ingest, "ASSETS_DIR", tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    opencpn_ingest.ingest(src, "ds1")
+
+    reg = registry.get_registry()
+    rec = reg.get("ds1")
+    from opencpn_ingest import _scale_to_zoom
+    assert rec is not None
+    assert rec.bbox == [0.0, 0.0, 1.0, 1.0]
+    assert rec.minzoom == _scale_to_zoom(2000)
+    assert rec.maxzoom == _scale_to_zoom(1000)
+    assert rec.senc_path and Path(rec.senc_path).exists()
+    assert rec.provenance_path and Path(rec.provenance_path).exists()

--- a/VDR/chart-tiler/tileserver.py
+++ b/VDR/chart-tiler/tileserver.py
@@ -746,21 +746,27 @@ def _serialize(rec: ChartRecord) -> Dict[str, Any]:
         "path": rec.path,
         "url": rec.url,
         "tags": rec.tags or [],
+        "senc_path": rec.senc_path,
+        "provenance_path": rec.provenance_path,
     }
 
 
 @app.get("/charts")
 def charts_summary() -> Dict[str, Any]:
-    datasets = [
-        {
-            "id": d.id,
-            "title": d.title,
-            "bounds": d.bounds,
-            "minzoom": d.minzoom,
-            "maxzoom": d.maxzoom,
-        }
-        for d in list_datasets()
-    ]
+    datasets = []
+    for d in list_datasets():
+        rec = reg.get(d.id)
+        datasets.append(
+            {
+                "id": d.id,
+                "title": d.title,
+                "bounds": d.bounds,
+                "minzoom": d.minzoom,
+                "maxzoom": d.maxzoom,
+                "senc_path": rec.senc_path if rec else None,
+                "provenance_path": rec.provenance_path if rec else None,
+            }
+        )
     return {"base": ["osm", "geotiff", "enc"], "enc": {"datasets": datasets}}
 
 


### PR DESCRIPTION
## Summary
- store ENC dataset bounds, zoom levels, and provenance when ingesting SENCs
- expose `senc_path` and provenance data through the chart registry and tileserver
- add test ensuring registry captures new SENC metadata

## Testing
- `pytest VDR/chart-tiler/tests/test_senc_registry.py -q`
- `pytest VDR/chart-tiler/tests/test_registry_scan.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68a208c2ac34832a805862470f1743bc