### PR TITLE
docs: document vendor bundle and API contracts

### DIFF
--- a/docs/api_contracts.md
+++ b/docs/api_contracts.md
@@ -1,0 +1,30 @@
+# API Contracts
+
+The OpenCPN API exposes a minimal REST surface for chart queries. This document locks down the final request and response semantics.
+
+## Endpoint Headers
+- `X-OCPN-Trace` – correlation identifier echoed in logs.
+- `X-OCPN-Bounds` – optional bounding box following the schema below.
+- `Content-Type` – all responses use `application/json`.
+
+## Bounds Schema
+```json
+{
+  "north": float,
+  "south": float,
+  "east": float,
+  "west": float
+}
+```
+Values are expressed in decimal degrees and must satisfy `south <= north` and `west <= east` with wrap-around handled by clients.
+
+## On-Wire Attribute Conventions
+- JSON keys use `snake_case`.
+- All timestamps are UTC ISO 8601 strings.
+- Enumerations serialize as lowercase strings.
+
+## Performance Budget
+Each endpoint must respond within **200 ms** at the 95th percentile and return payloads under **64 KB**.
+
+## Test Expectations
+Contract tests in `test/api` validate headers, bounds parsing, and attribute naming. Run `ctest` after schema changes to ensure backward compatibility.

--- a/docs/ocpn_mini_vendor.md
+++ b/docs/ocpn_mini_vendor.md
@@ -1,0 +1,25 @@
+# OCPN Mini Vendor Bundle
+
+The **ocpn-mini** build ships with a curated set of third-party libraries. This file documents which vendor code is included, the rules used to prune unnecessary files, and the provenance of each upstream project.
+
+## Vendor File List
+- `libs/rapidjson` – JSON parser for chart metadata.
+- `libs/tinyxml` – lightweight XML reader for plugin manifests.
+- `libs/sqlite` – embedded database backing settings storage.
+- `libs/lz4` – compression routines for tile archives.
+- `libs/pugixml` – fast DOM parser used in test helpers.
+
+## Pruning Rules
+- Include only headers and minimal sources required for runtime.
+- Drop all vendor test suites, examples, and platform-specific code not needed by ocpn-mini.
+- Remove documentation and tooling files that bloat the package.
+
+## Upstream Provenance
+- **rapidjson** sourced from <https://github.com/Tencent/rapidjson> (MIT) @ v1.1.0.
+- **tinyxml** sourced from <https://github.com/leethomason/tinyxml2> (zlib) @ v9.0.0.
+- **sqlite** sourced from <https://www.sqlite.org> (Public Domain) @ 3.45 series.
+- **lz4** sourced from <https://github.com/lz4/lz4> (BSD 2-Clause) @ v1.9.4.
+- **pugixml** sourced from <https://github.com/zeux/pugixml> (MIT) @ v1.14.
+
+## Performance and Testing
+Vendor payloads must remain under a compressed **5 MB** performance budget. After any vendor update, run `ctest` to confirm that integration tests continue to pass and measure startup time to stay within the budget.


### PR DESCRIPTION
## Summary
- add ocpn-mini vendor bundle documentation outlining included libraries, pruning rules, and provenance
- define API contract details including headers, bounds schema, and on-wire conventions

## Testing
- `pre-commit run --files docs/ocpn_mini_vendor.md docs/api_contracts.md`


------
https://chatgpt.com/codex/tasks/task_e_68a208ea2c18832abab8b3cea4253085