### PR TITLE
Refactor opencpn_bridge CLI

### DIFF
--- a/VDR/opencpn_bridge/cli/opb.py
+++ b/VDR/opencpn_bridge/cli/opb.py
@@ -1,61 +1,37 @@
 from __future__ import annotations
 
-import json
-import subprocess
-import sys
 from pathlib import Path
 
 import typer
 
-app = typer.Typer(help="OpenCPN bridge utilities")
+from opencpn_bridge.tools import stage_s52_assets
+from opencpn_bridge.py import ingest
 
-BASE_DIR = Path(__file__).resolve().parents[2]
-SCRIPTS_DIR = BASE_DIR / "scripts"
-ASSETS_DIR = BASE_DIR / "chart-tiler" / "assets" / "senc"
+app = typer.Typer(help="OpenCPN bridge utilities")
 
 
 @app.command("stage-s52")
 def stage_s52() -> None:
     """Stage S-52 assets."""
-    script = SCRIPTS_DIR / "stage_s52_assets.sh"
     try:
-        subprocess.run([str(script)], check=True)
+        stage_s52_assets.stage()
         typer.echo("S-52 assets staged")
-    except subprocess.CalledProcessError as exc:
+    except Exception as exc:  # pragma: no cover - defensive
         typer.echo(f"stage-s52 failed: {exc}", err=True)
-        raise typer.Exit(exc.returncode)
+        raise typer.Exit(1)
 
 
 @app.command()
 def ingest(
     dataset_id: str,
     src_root: Path,
-    type: str = typer.Option(..., "--type", "-t", help="Dataset type", metavar="enc|cm93"),
+    dataset_type: str = typer.Option(..., "--type", "-t", help="Dataset type", metavar="enc|cm93"),
 ) -> None:
-    """Build a SENC cache and register it."""
-    if type not in {"enc", "cm93"}:
+    """Ingest a dataset into the SENC cache and registry."""
+    if dataset_type not in {"enc", "cm93"}:
         raise typer.BadParameter("type must be 'enc' or 'cm93'")
-    chart_tiler = BASE_DIR / "chart-tiler"
-    sys.path.insert(0, str(chart_tiler))
-    from registry import get_registry  # type: ignore
-    from opencpn_bridge import build_senc, query_features
-
-    ASSETS_DIR.mkdir(parents=True, exist_ok=True)
-    senc_path = ASSETS_DIR / f"{dataset_id}.senc"
     try:
-        build_senc(str(src_root), str(senc_path))
-        info = query_features(str(senc_path))
-        meta = {
-            "id": dataset_id,
-            "kind": type,
-            "bbox": info.get("bbox", [0, 0, 0, 0]),
-            "scale_min": int(info.get("scale_min", 0)),
-            "scale_max": int(info.get("scale_max", 0)),
-        }
-        meta_path = senc_path.with_name(f"{senc_path.stem}.senc.json")
-        meta_path.write_text(json.dumps(meta))
-        registry = get_registry()
-        registry.register_senc(meta_path, senc_path)
+        ingest.ingest_dataset(dataset_id, str(src_root), dataset_type)
         typer.echo(f"Ingested dataset {dataset_id}")
     except Exception as exc:  # pragma: no cover - defensive
         typer.echo(f"ingest failed: {exc}", err=True)
@@ -68,11 +44,9 @@ def serve(
     port: int = typer.Option(8000, help="Listen port"),
 ) -> None:
     """Run the FastAPI tile server."""
-    chart_tiler = BASE_DIR / "chart-tiler"
-    sys.path.insert(0, str(chart_tiler))
     try:
         import uvicorn
-        uvicorn.run("tileserver:app", host=host, port=port)
+        uvicorn.run("opencpn_bridge.tileserver.app:app", host=host, port=port)
     except Exception as exc:  # pragma: no cover - defensive
         typer.echo(f"serve failed: {exc}", err=True)
         raise typer.Exit(1)

--- a/VDR/opencpn_bridge/pyproject.toml
+++ b/VDR/opencpn_bridge/pyproject.toml
@@ -9,6 +9,9 @@ description = "Python bindings for OpenCPN SENC generation and feature queries"
 authors = [{name = "OpenCPN"}]
 requires-python = ">=3.8"
 
+[project.scripts]
+opb = "opencpn_bridge.cli.opb:app"
+
 [project.urls]
 Homepage = "https://opencpn.org"
 


### PR DESCRIPTION
## Summary
- simplify CLI to use internal modules for staging assets, ingesting datasets and serving tiles
- expose CLI entry point via `opb` script

## Testing
- `pytest opencpn_bridge/tests VDR/opencpn_bridge/tests` *(fails: ImportError: cannot import name 'opencpn_bridge' from partially initialized module 'opencpn_bridge.py')*
- `pytest VDR/opencpn_bridge/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a246643d04832ab6a9bf80ebc7caf3