### PR TITLE
Add FastAPI tile server routes and metrics

### DIFF
--- a/VDR/opencpn_bridge/tests/test_tileserver_metrics.py
+++ b/VDR/opencpn_bridge/tests/test_tileserver_metrics.py
@@ -6,26 +6,37 @@ from fastapi.testclient import TestClient
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from tileserver.app import app  # type: ignore
+import tileserver.app as app_module  # type: ignore
+
+
+def _fake_query_tile_mvt(kind: str, chart_id: str, z: int, x: int, y: int):
+    """Return deterministic bytes for testing without native dependency."""
+
+    return b"mvt", "etag", False
 
 
 def test_metrics_increment():
-    client = TestClient(app)
+    # Patch the native bridge function with a lightweight stub
+    app_module.query_tile_mvt = _fake_query_tile_mvt  # type: ignore
+    client = TestClient(app_module.app)
 
-    r1 = client.get("/tiles/0/0/0.png")
+    r1 = client.get("/tiles/enc/test/0/0/0.pbf")
     assert r1.status_code == 200
+    assert r1.headers["Content-Type"] == "application/x-protobuf"
+    assert r1.headers["Cache-Control"] == "public,max-age=3600"
+    assert r1.headers["ETag"] == "etag"
     size = len(r1.content)
 
     m1 = client.get("/metrics")
     assert m1.status_code == 200
     txt1 = m1.text
-    assert f'tile_render_seconds_count{{kind="tile"}} 1.0' in txt1
-    assert f'tile_bytes_total{{kind="tile"}} {float(size)}' in txt1
+    assert f'tile_render_seconds_count{{kind="enc"}} 1.0' in txt1
+    assert f'tile_bytes_total{{kind="enc"}} {float(size)}' in txt1
 
-    r2 = client.get("/tiles/0/0/0.png")
+    r2 = client.get("/tiles/enc/test/0/0/0.pbf")
     assert r2.status_code == 200
 
     m2 = client.get("/metrics")
     txt2 = m2.text
-    assert f'tile_render_seconds_count{{kind="tile"}} 2.0' in txt2
-    assert f'tile_bytes_total{{kind="tile"}} {float(size*2)}' in txt2
+    assert f'tile_render_seconds_count{{kind="enc"}} 2.0' in txt2
+    assert f'tile_bytes_total{{kind="enc"}} {float(size*2)}' in txt2

--- a/VDR/opencpn_bridge/tileserver/app.py
+++ b/VDR/opencpn_bridge/tileserver/app.py
@@ -1,65 +1,115 @@
+"""Minimal FastAPI tileserver backed by ``query_tile_mvt``.
+
+Exposes endpoints for health checks, Prometheus metrics and vector tiles for
+ENC and CM93 chart datasets.  Tile responses include appropriate caching
+headers and optional gzip compression if the underlying data has been
+pre-compressed.
+"""
+
 from __future__ import annotations
 
-import base64
-import os
+import importlib
 import time
-from collections import OrderedDict
-from typing import Tuple
+from typing import Any, Dict, List
 
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI, HTTPException, Response
 
 from .metrics import (
-    REGISTRY,
     CONTENT_TYPE_LATEST,
+    REGISTRY,
     generate_latest,
-    tile_render_seconds,
     tile_bytes_total,
+    tile_render_seconds,
 )
+
+# Lazily import the native bridge module to access ``query_tile_mvt``
+try:  # pragma: no cover - optional native dependency
+    _bridge = importlib.import_module("opencpn_bridge")
+    query_tile_mvt = getattr(_bridge, "query_tile_mvt", None)
+except Exception:  # pragma: no cover - dependency missing
+    query_tile_mvt = None
+
+# ``list_datasets`` lives in the chart registry package which may not be
+# available in all environments (e.g. unit tests), so import lazily.
+try:  # pragma: no cover - optional dependency
+    from registry import list_datasets as _list_datasets  # type: ignore
+except Exception:  # pragma: no cover - optional dependency missing
+    _list_datasets = None
 
 app = FastAPI()
 
-# ---------------------------------------------------------------------------
-# Simple in-process LRU cache
-# ---------------------------------------------------------------------------
-_CACHE_SIZE = int(os.environ.get("TILE_CACHE_SIZE", "64"))
-_tile_cache: "OrderedDict[Tuple[int,int,int], bytes]" = OrderedDict()
 
-# 1x1 transparent PNG
-PNG_1X1 = base64.b64decode(
-    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jP1kAAAAASUVORK5CYII="
-)
+def _build_tile_response(kind: str, chart_id: str, z: int, x: int, y: int) -> Response:
+    """Render a tile and wrap it in an HTTP response."""
 
+    if query_tile_mvt is None:  # pragma: no cover - native dependency missing
+        raise HTTPException(status_code=500, detail="query_tile_mvt unavailable")
 
-@app.middleware("http")
-async def _metrics_middleware(request: Request, call_next):
     start = time.perf_counter()
-    response = await call_next(request)
-    if request.url.path.startswith("/tiles/"):
-        elapsed = time.perf_counter() - start
-        tile_render_seconds.labels(kind="tile").observe(elapsed)
-    return response
+    data, tile_hash, compressed = query_tile_mvt(kind, chart_id, z, x, y)
+    tile_render_seconds.labels(kind=kind).observe(time.perf_counter() - start)
+    tile_bytes_total.labels(kind=kind).inc(len(data))
+
+    headers = {
+        "Cache-Control": "public,max-age=3600",
+    }
+    if tile_hash:
+        headers["ETag"] = tile_hash
+    if compressed:
+        headers["Content-Encoding"] = "gzip"
+
+    return Response(
+        content=data,
+        media_type="application/x-protobuf",
+        headers=headers,
+    )
 
 
-def _cache_key(z: int, x: int, y: int) -> Tuple[int, int, int]:
-    return z, x, y
+@app.get("/tiles/enc/{chart_id}/{z}/{x}/{y}.pbf")
+def enc_tile(chart_id: str, z: int, x: int, y: int) -> Response:
+    """Return ENC tile as Mapbox Vector Tile."""
+
+    return _build_tile_response("enc", chart_id, z, x, y)
 
 
-@app.get("/tiles/{z}/{x}/{y}.png")
-def get_tile(z: int, x: int, y: int) -> Response:
-    key = _cache_key(z, x, y)
-    data = _tile_cache.get(key)
-    if data is None:
-        data = PNG_1X1
-        _tile_cache[key] = data
-        _tile_cache.move_to_end(key)
-        if len(_tile_cache) > _CACHE_SIZE:
-            _tile_cache.popitem(last=False)
-    else:
-        _tile_cache.move_to_end(key)
-    tile_bytes_total.labels(kind="tile").inc(len(data))
-    return Response(data, media_type="image/png")
+@app.get("/tiles/cm93/{chart_id}/{z}/{x}/{y}.pbf")
+def cm93_tile(chart_id: str, z: int, x: int, y: int) -> Response:
+    """Return CM93 tile as Mapbox Vector Tile."""
+
+    return _build_tile_response("cm93", chart_id, z, x, y)
+
+
+@app.get("/charts")
+def charts() -> dict[str, Any]:
+    """List datasets known to the registry."""
+
+    datasets: list[dict[str, Any]] = []
+    if _list_datasets is not None:  # pragma: no branch - depends on optional import
+        try:
+            for d in _list_datasets():
+                datasets.append(
+                    {
+                        "id": d.id,
+                        "title": d.title,
+                        "bounds": d.bounds,
+                        "minzoom": d.minzoom,
+                        "maxzoom": d.maxzoom,
+                    }
+                )
+        except Exception:  # pragma: no cover - registry failure
+            datasets = []
+    return {"base": ["osm", "geotiff", "enc"], "enc": {"datasets": datasets}}
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, bool]:
+    """Kubernetes-style liveness probe."""
+
+    return {"ok": True}
 
 
 @app.get("/metrics")
 def metrics() -> Response:
+    """Expose Prometheus metrics."""
+
     return Response(generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST)

--- a/VDR/opencpn_bridge/tileserver/metrics.py
+++ b/VDR/opencpn_bridge/tileserver/metrics.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
-"""Prometheus metrics for the lightweight tile server."""
+"""Prometheus metrics for the lightweight tile server.
+
+This module exposes two metrics shared by the FastAPI application:
+
+``tile_render_seconds``
+    Histogram tracking how long it takes to render a tile.
+
+``tile_bytes_total``
+    Counter recording the number of bytes returned to clients.
+"""
 
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
@@ -9,6 +18,7 @@ from prometheus_client import (
     generate_latest,
 )
 
+# Separate registry so tests can introspect without polluting default metrics
 REGISTRY = CollectorRegistry()
 
 # Histogram tracking the render latency for tiles.


### PR DESCRIPTION
## Summary
- replace tile server with dedicated routes for ENC and CM93 tiles
- expose charts listing and health check endpoints
- add Prometheus metrics helpers and tests

## Testing
- `pre-commit run --files VDR/opencpn_bridge/tileserver/app.py VDR/opencpn_bridge/tileserver/metrics.py VDR/opencpn_bridge/tests/test_tileserver_metrics.py`
- `pytest VDR/opencpn_bridge/tests/test_tileserver_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2468df96c832a9db0d415f9681538