### PR TITLE
Add Python bridge stubs with fallback to compiled extension

### DIFF
--- a/opencpn_bridge/py/__init__.py
+++ b/opencpn_bridge/py/__init__.py
@@ -1,7 +1,6 @@
 from .ingest import ingest_dataset
-
-__all__ = ["ingest_dataset"]
-
 from .bridge import build_senc, query_tile_mvt
+
+__all__ = ["ingest_dataset", "build_senc", "query_tile_mvt"]
 
 

--- a/opencpn_bridge/py/bridge.py
+++ b/opencpn_bridge/py/bridge.py
@@ -1,15 +1,55 @@
-"""Python wrappers around the stub OpenCPN bridge."""
+"""Python wrappers around the OpenCPN bridge.
+
+This module prefers a compiled extension but falls back to lightweight
+Python stubs when the extension is unavailable. The stubs mimic the
+tileserver contract used by the real bridge.
+"""
+
 from __future__ import annotations
 
-from . import opencpn_bridge as _bridge
+import json
+from pathlib import Path
+
+# Minimal empty Mapbox Vector Tile with a single layer named ``empty``.
+EMPTY_MVT_BYTES = bytes.fromhex("1a0c0a05656d7074792880207802")
+
+try:  # pragma: no cover - exercised via integration tests
+    from . import opencpn_bridge as _bridge  # type: ignore
+except Exception:  # pragma: no cover - extension missing
+    _bridge = None
 
 
-def build_senc(chart_path: str, output_dir: str) -> str:
-    """Create a stub SENC and return the output directory."""
-    return _bridge.build_senc(chart_path, output_dir)
+if _bridge is not None:
+    build_senc = _bridge.build_senc
+    query_tile_mvt = _bridge.query_tile_mvt
+else:
 
+    def build_senc(
+        dataset_root: str,
+        out_dir: str,
+        *,
+        bounds: tuple[float, float, float, float] | None = None,
+        minzoom: int | None = None,
+        maxzoom: int | None = None,
+    ) -> str:
+        """Create a stub SENC and return a fake handle path."""
+        out = Path(out_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        provenance = {
+            "dataset_root": dataset_root,
+            "bounds": bounds,
+            "minzoom": minzoom,
+            "maxzoom": maxzoom,
+        }
+        (out / "provenance.json").write_text(json.dumps(provenance))
+        return str(out / "handle.fake")
 
-def query_tile_mvt(senc_root: str, z: int, x: int, y: int) -> bytes:
-    """Return an empty Mapbox Vector Tile for the given coordinates."""
-    return _bridge.query_tile_mvt(senc_root, z, x, y)
+    def query_tile_mvt(
+        senc_root: str,
+        z: int,
+        x: int,
+        y: int,
+    ) -> tuple[bytes, str, bool]:
+        """Return a minimal empty Mapbox Vector Tile."""
+        return (EMPTY_MVT_BYTES, "", False)
 


### PR DESCRIPTION
## Summary
- Implement fallback stubs for `build_senc` and `query_tile_mvt` when the compiled bridge extension is unavailable
- Expose `build_senc` and `query_tile_mvt` from `opencpn_bridge`'s top-level package

## Testing
- `pytest opencpn_bridge/py/tests/test_ingest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a24f8c2648832aa8aa5b7e431ca539