### PR TITLE
Add C++ stub module and build rules for opencpn_bridge

### DIFF
--- a/opencpn_bridge/CMakeLists.txt
+++ b/opencpn_bridge/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.15)
+project(opencpn_bridge LANGUAGES CXX)
+
+include(FetchContent)
+FetchContent_Declare(
+  pybind11
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
+)
+FetchContent_MakeAvailable(pybind11)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dist)
+
+option(OPB_WITH_OCPN_MINI "Build with ocpn-mini vendor sources" OFF)
+option(OPB_STUB_ONLY "Build stub implementation only" ON)
+
+if(OPB_STUB_ONLY)
+  pybind11_add_module(opencpn_bridge MODULE cpp/stub/bridge_stub.cpp)
+elseif(OPB_WITH_OCPN_MINI)
+  message(STATUS "OPB_WITH_OCPN_MINI is not implemented; building stub only")
+endif()

--- a/opencpn_bridge/cpp/stub/bridge_stub.cpp
+++ b/opencpn_bridge/cpp/stub/bridge_stub.cpp
@@ -1,0 +1,44 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <fstream>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+// Build a stub SENC and write a dummy provenance.json file.
+std::string build_senc(const std::string &chart_path,
+                       const std::string &output_dir) {
+  (void)chart_path;  // unused
+  fs::create_directories(output_dir);
+  std::ofstream(output_dir + "/provenance.json") << "{\"stub\": true}\n";
+  return output_dir;
+}
+
+// Return an empty Mapbox Vector Tile for the requested coordinates.
+std::string query_tile_mvt(const std::string &senc_root, int z, int x, int y) {
+  (void)senc_root;
+  (void)z;
+  (void)x;
+  (void)y;
+  return std::string();
+}
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(opencpn_bridge, m) {
+  m.doc() = "Python bindings for the OpenCPN stub bridge";
+
+  m.def("build_senc", &build_senc, py::arg("chart_path"), py::arg("output_dir"),
+        "Build a stub SENC and write a dummy provenance.json, returning the "
+        "output path");
+
+  m.def(
+      "query_tile_mvt",
+      [](const std::string &senc_root, int z, int x, int y) {
+        auto data = query_tile_mvt(senc_root, z, x, y);
+        return py::bytes(data);
+      },
+      py::arg("senc_root"), py::arg("z"), py::arg("x"), py::arg("y"),
+      "Return an empty Mapbox Vector Tile for the requested coordinates");
+}


### PR DESCRIPTION
## Summary
- implement stub `build_senc` and `query_tile_mvt` directly in C++ and expose them via pybind11
- add top-level CMakeLists to build stub module and place artifacts under `dist`

## Testing
- `pre-commit run --files opencpn_bridge/cpp/stub/bridge_stub.cpp opencpn_bridge/CMakeLists.txt`
- `cmake -S opencpn_bridge -B opencpn_bridge/build -DOPB_STUB_ONLY=ON`
- `cmake --build opencpn_bridge/build`
- `pytest opencpn_bridge/tests/test_bbox_math.py opencpn_bridge/tests/test_stub_tiles.py`


------
https://chatgpt.com/codex/tasks/task_e_68a24f9b67e4832aa2d653b9015eca90