### PR TITLE
Include opencpn_bridge subpackages

### DIFF
--- a/VDR/opencpn_bridge/pyproject.toml
+++ b/VDR/opencpn_bridge/pyproject.toml
@@ -16,5 +16,17 @@ opb = "opencpn_bridge.cli.opb:app"
 Homepage = "https://opencpn.org"
 
 [tool.setuptools]
-packages = ["opencpn_bridge"]
-package-dir = {"opencpn_bridge" = "py"}
+packages = [
+    "opencpn_bridge",
+    "opencpn_bridge.cli",
+    "opencpn_bridge.tools",
+    "opencpn_bridge.tileserver",
+    "opencpn_bridge.registry",
+]
+
+[tool.setuptools.package-dir]
+"opencpn_bridge" = "py"
+"opencpn_bridge.cli" = "cli"
+"opencpn_bridge.tools" = "tools"
+"opencpn_bridge.tileserver" = "tileserver"
+"opencpn_bridge.registry" = "registry"


### PR DESCRIPTION
## Summary
- Package the `cli`, `tools`, `tileserver`, and `registry` modules under `opencpn_bridge`.
- Preserve the `opb` CLI entry point.

## Testing
- `pytest VDR/opencpn_bridge/tests -q` *(fails: IndentationError in test_tileserver_metrics.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a24fa193d8832ab1d30c9b5ebd2e87