### PR TITLE
Add metrics increment test for tileserver

### DIFF
--- a/VDR/opencpn_bridge/tests/test_tileserver_metrics.py
+++ b/VDR/opencpn_bridge/tests/test_tileserver_metrics.py
@@ -2,15 +2,12 @@ import sys
 from pathlib import Path
 
 from fastapi.testclient import TestClient
-import pytest
 
-
-# Ensure the repository root is on the Python path so the packaged tileserver
-# module can be imported regardless of the current working directory.
+# Ensure the VDR package root is on the Python path so the tileserver module can
+# be imported regardless of the current working directory.
 ROOT = Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "VDR" / "opencpn_bridge"))
 
-from opencpn_bridge.tileserver.app import app  # type: ignore
 import tileserver.app as app_module  # type: ignore
 
 
@@ -19,16 +16,11 @@ def _fake_query_tile_mvt(kind: str, chart_id: str, z: int, x: int, y: int):
 
     return b"mvt", "etag", False
 
+
 def test_metrics_increment():
     # Patch the native bridge function with a lightweight stub
     app_module.query_tile_mvt = _fake_query_tile_mvt  # type: ignore
     client = TestClient(app_module.app)
-
-## probably error in code on the next couple of rows
-xx
-    r1 = client.get("/tiles/0/0/0.png")
-    if r1.status_code != 200:  # pragma: no cover - endpoint unsupported
-        pytest.skip("tile endpoint unavailable")
 
     r1 = client.get("/tiles/enc/test/0/0/0.pbf")
     assert r1.status_code == 200
@@ -48,6 +40,5 @@ xx
 
     m2 = client.get("/metrics")
     txt2 = m2.text
-    assert f'tile_render_seconds_count{{kind="tile"}} 2.0' in txt2
-    assert f'tile_bytes_total{{kind="tile"}} {float(size*2)}' in txt2
-
+    assert f'tile_render_seconds_count{{kind="enc"}} 2.0' in txt2
+    assert f'tile_bytes_total{{kind="enc"}} {float(size*2)}' in txt2


### PR DESCRIPTION
## Summary
- ensure metrics test imports Path and sys and sets up VDR package path
- verify tile metrics counters increment after repeated ENC tile requests

## Testing
- `pytest VDR/opencpn_bridge/tests/test_tileserver_metrics.py::test_metrics_increment -q`


------
https://chatgpt.com/codex/tasks/task_e_68a24fbf95b0832aab11da9f7d92cb99