### PR TITLE
Expose opencpn bridge utilities in Python package

### DIFF
--- a/VDR/opencpn_bridge/py/__init__.py
+++ b/VDR/opencpn_bridge/py/__init__.py
@@ -1,6 +1,4 @@
 from .ingest import ingest_dataset
-
-__all__ = ["ingest_dataset"]
 from .bridge import build_senc, query_tile_mvt
 
-__all__ = ["build_senc", "query_tile_mvt"]
+__all__ = ["ingest_dataset", "build_senc", "query_tile_mvt"]


### PR DESCRIPTION
## Summary
- expose ingest_dataset, build_senc and query_tile_mvt from opencpn_bridge

## Testing
- `pytest VDR/opencpn_bridge/py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a25a317410832a85821b20c84c7da6