### PR TITLE
Add stubbed bridge wrapper with fallback

### DIFF
--- a/VDR/opencpn_bridge/py/bridge.py
+++ b/VDR/opencpn_bridge/py/bridge.py
@@ -1,3 +1,16 @@
+"""Python wrappers around the OpenCPN bridge.
+
+The native :mod:`opencpn_bridge` extension is optional.  When it cannot be
+imported, lightweight stub implementations are provided so that other parts of
+the package can operate in environments where the extension is unavailable.
+
+All public functions return a three-tuple ``(data, etag, compressed)``:
+
+* ``data`` is the requested payload, such as a SENC handle path or tile bytes.
+* ``etag`` is an optional identifier for the payload, ``None`` if unknown.
+* ``compressed`` signals if ``data`` is already gzip compressed.
+"""
+
 from __future__ import annotations
 
 import json
@@ -6,41 +19,40 @@ from pathlib import Path
 # Minimal empty Mapbox Vector Tile with a single layer named "empty".
 _EMPTY_MVT = bytes.fromhex("1a0c0a05656d7074792880207802")
 
-def build_senc(dataset_root: str, out_dir: str) -> str:
-    """Create a stub SENC and return a fake handle path.
+try:  # pragma: no cover - exercised when the native module is present
+    import opencpn_bridge as _bridge  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover - module missing or failed to import
+    _bridge = None
 
-    A minimal ``provenance.json`` file is written to ``out_dir`` recording
-    ``dataset_root``.  The returned handle is a path within ``out_dir`` that
-    does not correspond to a real resource.
-    """
-    out = Path(out_dir)
-    out.mkdir(parents=True, exist_ok=True)
-    (out / "provenance.json").write_text(json.dumps({"dataset_root": dataset_root}))
-    return str(out / "handle.fake")
+    def build_senc(dataset_root: str, out_dir: str) -> tuple[str, None, bool]:
+        """Create a stub SENC and return a fake handle path.
 
-def query_tile_mvt(
-    handle_or_path: str,
-    z: int,
-    x: int,
-    y: int,
-    plane: int,
-    safety: int,
-    shallow: int,
-    deep: int,
-) -> bytes:
-    """Return a tiny, valid but empty Mapbox Vector Tile."""
-    return _EMPTY_MVT
-"""Python wrappers around the OpenCPN bridge."""
-from __future__ import annotations
+        A minimal ``provenance.json`` file is written to ``out_dir`` recording
+        ``dataset_root``.  The returned tuple contains the fake handle path,
+        ``None`` for the ETag and ``False`` to indicate the data is not
+        compressed.
+        """
 
-from . import opencpn_bridge as _bridge
+        out = Path(out_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "provenance.json").write_text(
+            json.dumps({"dataset_root": dataset_root})
+        )
+        handle = str(out / "handle.fake")
+        return handle, None, False
 
+    def query_tile_mvt(
+        senc_root: str,
+        z: int,
+        x: int,
+        y: int,
+    ) -> tuple[bytes, None, bool]:
+        """Return a tiny, valid but empty Mapbox Vector Tile."""
 
-def build_senc(chart_path: str, output_dir: str) -> str:
-    """Create a SENC and return the output directory."""
-    return _bridge.build_senc(chart_path, output_dir)
+        return _EMPTY_MVT, None, False
 
+else:  # pragma: no cover - exercised when the native module is available
+    # Expose the native implementations directly.
+    build_senc = _bridge.build_senc  # type: ignore[attr-defined]
+    query_tile_mvt = _bridge.query_tile_mvt  # type: ignore[attr-defined]
 
-def query_tile_mvt(senc_root: str, z: int, x: int, y: int) -> bytes:
-    """Return an MVT tile for the given chart handle."""
-    return _bridge.query_tile_mvt(senc_root, z, x, y)


### PR DESCRIPTION
## Summary
- add Python bridge wrapper that falls back to internal stubs when the native `opencpn_bridge` extension isn't available
- document `(data, etag, compressed)` return contract for bridge helpers

## Testing
- `pytest VDR/opencpn_bridge/tests/test_tileserver_metrics.py::test_metrics_increment -q`
- `pytest VDR/opencpn_bridge/tests/test_stub_tiles.py::test_stub_tile_roundtrip -q` (skipped)


------
https://chatgpt.com/codex/tasks/task_e_68a25a42bc44832a81fafa2e31972e4b