### PR TITLE
Add skeleton wrapper and ingest script

### DIFF
--- a/VDR/s57_CM93map_import/ingest.py
+++ b/VDR/s57_CM93map_import/ingest.py
@@ -1,0 +1,18 @@
+"""Stub ingest script for s57 and CM93 charts using ocpn_min wrapper."""
+import subprocess
+import sys
+
+def run_wrapper(mode, src):
+    cmd = ["../../wrapper/build/ocpn_min", mode, "--src", src]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    for line in proc.stdout:
+        sys.stdout.write(line)
+    proc.wait()
+    return proc.returncode
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("usage: ingest.py <s57|cm93> <src>")
+        sys.exit(1)
+    rc = run_wrapper(sys.argv[1], sys.argv[2])
+    sys.exit(rc)

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.18)
+project(ocpn_min LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+add_definitions(-DOCPN_MIN_NO_GUI)
+
+# placeholder vendor file list - users should populate with actual OpenCPN sources
+file(STRINGS vendor_filelist.cmake OCPN_SRCS)
+
+add_library(ocpn_core STATIC ${OCPN_SRCS})
+
+target_include_directories(ocpn_core PRIVATE ${CMAKE_SOURCE_DIR}/shim)
+
+add_executable(ocpn_min src/main.cpp src/emit_ndjson.cpp src/attr_codec.cpp src/bbox.cpp)
+target_link_libraries(ocpn_min PRIVATE ocpn_core)

--- a/wrapper/shim/fs.hpp
+++ b/wrapper/shim/fs.hpp
@@ -1,0 +1,3 @@
+#pragma once
+#include <filesystem>
+namespace ocpn { using Path = std::filesystem::path; }

--- a/wrapper/shim/geo.hpp
+++ b/wrapper/shim/geo.hpp
@@ -1,0 +1,4 @@
+#pragma once
+namespace ocpn {
+struct BBox { double minx, miny, maxx, maxy; };
+}

--- a/wrapper/shim/log.hpp
+++ b/wrapper/shim/log.hpp
@@ -1,0 +1,3 @@
+#pragma once
+#include <iostream>
+namespace ocpn { inline void log(const std::string& m){ std::cerr << m << std::endl; } }

--- a/wrapper/shim/strings.hpp
+++ b/wrapper/shim/strings.hpp
@@ -1,0 +1,3 @@
+#pragma once
+#include <string>
+namespace ocpn { using String = std::string; }

--- a/wrapper/src/attr_codec.cpp
+++ b/wrapper/src/attr_codec.cpp
@@ -1,0 +1,2 @@
+#include "attr_codec.hpp"
+// placeholder implementation

--- a/wrapper/src/attr_codec.hpp
+++ b/wrapper/src/attr_codec.hpp
@@ -1,0 +1,2 @@
+#pragma once
+struct Attr { std::string k; char t; std::string v; };

--- a/wrapper/src/bbox.cpp
+++ b/wrapper/src/bbox.cpp
@@ -1,0 +1,2 @@
+#include "bbox.hpp"
+// placeholder implementation

--- a/wrapper/src/bbox.hpp
+++ b/wrapper/src/bbox.hpp
@@ -1,0 +1,2 @@
+#pragma once
+struct BBox { double minx, miny, maxx, maxy; };

--- a/wrapper/src/emit_ndjson.cpp
+++ b/wrapper/src/emit_ndjson.cpp
@@ -1,0 +1,2 @@
+#include "emit_ndjson.hpp"
+// placeholder implementation

--- a/wrapper/src/emit_ndjson.hpp
+++ b/wrapper/src/emit_ndjson.hpp
@@ -1,0 +1,4 @@
+#pragma once
+#include <string>
+#include <iostream>
+inline void emit_line(const std::string& s){ std::cout << s << '\n'; }

--- a/wrapper/src/main.cpp
+++ b/wrapper/src/main.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include "emit_ndjson.hpp"
+#include "attr_codec.hpp"
+#include "bbox.hpp"
+
+int main(int argc, char** argv){
+    std::cout << "{\"type\":\"Dataset\"}\n";
+    // placeholder feature emission
+    std::cout << "{\"type\":\"Feature\"}\n";
+    return 0;
+}

--- a/wrapper/vendor_filelist.cmake
+++ b/wrapper/vendor_filelist.cmake
@@ -1,0 +1,9 @@
+../gui/src/cm93.cpp
+../gui/src/s57chart.cpp
+../libs/iso8211/src/ddffield.cpp
+../libs/iso8211/src/ddffielddefn.cpp
+../libs/iso8211/src/ddfmodule.cpp
+../libs/iso8211/src/ddfrecord.cpp
+../libs/iso8211/src/ddfrecordindex.cpp
+../libs/iso8211/src/ddfsubfielddefn.cpp
+../libs/iso8211/src/ddfutils.cpp


### PR DESCRIPTION
## Summary
- scaffold ultra-mini OpenCPN wrapper with CMake, shims, and stub sources
- add Python ingest stub for s57/CM93 chart import under VDR

## Testing
- `cmake -S wrapper -B wrapper/build` *(fails: Cannot find wx/wxprec.h)*
- `cmake --build wrapper/build` *(fails: missing wx/wxprec.h)*
- `python -m py_compile VDR/s57_CM93map_import/ingest.py`


------
https://chatgpt.com/codex/tasks/task_e_68a38f673678832a94bed338b79318c4