### PR TITLE
feat: flesh out ocpn wrapper and ingest

### DIFF
--- a/VDR/s57_CM93map_import/ingest.py
+++ b/VDR/s57_CM93map_import/ingest.py
@@ -1,18 +1,51 @@
-"""Stub ingest script for s57 and CM93 charts using ocpn_min wrapper."""
+"""Simple ingestion helper for the ocpn_min wrapper.
+
+The script executes the ultra‑mini OpenCPN wrapper and streams the emitted
+NDJSON lines to stdout.  When ``--gzip`` is supplied the stream is transparently
+decompressed before forwarding.  The function is intentionally small – the
+calling process is responsible for piping the output to PostGIS or further
+processing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
 import subprocess
 import sys
 
-def run_wrapper(mode, src):
-    cmd = ["../../wrapper/build/ocpn_min", mode, "--src", src]
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-    for line in proc.stdout:
-        sys.stdout.write(line)
+
+def run_wrapper(args: argparse.Namespace) -> int:
+    cmd = ["../../wrapper/build/ocpn_min", args.mode, "--src", args.src]
+    if args.bbox:
+        cmd += ["--bbox", args.bbox]
+    if args.full_attrs:
+        cmd.append("--full-attrs")
+    if args.gzip:
+        cmd.append("--gzip")
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stream = gzip.GzipFile(fileobj=proc.stdout) if args.gzip else proc.stdout
+
+    for raw in stream:
+        # Forward lines to stdout; caller may capture and import to PostGIS.
+        sys.stdout.buffer.write(raw)
+
     proc.wait()
+    sys.stderr.buffer.write(proc.stderr.read())
     return proc.returncode
 
+
+def parse_cli() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run ocpn_min wrapper")
+    p.add_argument("mode", choices=["s57", "cm93"], help="reader mode")
+    p.add_argument("src", help="path to chart source")
+    p.add_argument("--bbox", help="optional bbox minx,miny,maxx,maxy")
+    p.add_argument("--full-attrs", action="store_true", help="emit full attribute list")
+    p.add_argument("--gzip", action="store_true", help="wrapper emits gzip to stdout")
+    return p.parse_args()
+
+
 if __name__ == "__main__":
-    if len(sys.argv) < 3:
-        print("usage: ingest.py <s57|cm93> <src>")
-        sys.exit(1)
-    rc = run_wrapper(sys.argv[1], sys.argv[2])
-    sys.exit(rc)
+    ns = parse_cli()
+    sys.exit(run_wrapper(ns))

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -1,15 +1,38 @@
 cmake_minimum_required(VERSION 3.18)
 project(ocpn_min LANGUAGES CXX)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_definitions(-DOCPN_MIN_NO_GUI)
 
-# placeholder vendor file list - users should populate with actual OpenCPN sources
+#
+# Vendor OpenCPN sources
+# The list is generated via the discovery script described in the project
+# documentation.  Each entry is relative to the OpenCPN repository root.
+#
 file(STRINGS vendor_filelist.cmake OCPN_SRCS)
+
+find_package(ZLIB REQUIRED)
 
 add_library(ocpn_core STATIC ${OCPN_SRCS})
 
-target_include_directories(ocpn_core PRIVATE ${CMAKE_SOURCE_DIR}/shim)
+target_include_directories(ocpn_core PRIVATE
+    ${CMAKE_SOURCE_DIR}/shim
+    ${CMAKE_SOURCE_DIR}/..
+    ${CMAKE_SOURCE_DIR}/../include
+    ${CMAKE_SOURCE_DIR}/../gui/include
+    ${CMAKE_SOURCE_DIR}/../libs/iso8211/src
+    ${CMAKE_SOURCE_DIR}/../libs/iso8211/include
+    ${CMAKE_SOURCE_DIR}/../libs/s57-charts/include
+    ${CMAKE_SOURCE_DIR}/../libs/s57-charts/src
+    )
 
-add_executable(ocpn_min src/main.cpp src/emit_ndjson.cpp src/attr_codec.cpp src/bbox.cpp)
-target_link_libraries(ocpn_min PRIVATE ocpn_core)
+add_executable(ocpn_min
+    src/main.cpp
+    src/emit_ndjson.cpp
+    src/attr_codec.cpp
+    src/bbox.cpp)
+
+target_include_directories(ocpn_min PRIVATE ${CMAKE_SOURCE_DIR}/shim)
+target_link_libraries(ocpn_min PRIVATE ocpn_core ZLIB::ZLIB)
+

--- a/wrapper/shim/log.hpp
+++ b/wrapper/shim/log.hpp
@@ -1,3 +1,8 @@
 #pragma once
 #include <iostream>
-namespace ocpn { inline void log(const std::string& m){ std::cerr << m << std::endl; } }
+
+namespace ocpn {
+inline void log(const std::string& m) { std::cerr << m << std::endl; }
+inline void log_error(const std::string& m) { std::cerr << "error: " << m << std::endl; }
+inline void log_info(const std::string& m) { std::cerr << "info: " << m << std::endl; }
+}

--- a/wrapper/shim/strings.hpp
+++ b/wrapper/shim/strings.hpp
@@ -1,3 +1,29 @@
 #pragma once
 #include <string>
+#include <vector>
+
+// Minimal replacements for wxWidgets string utilities used by the vendored
+// OpenCPN sources.  The goal is to keep the wrapper self contained without a
+// wxWidgets dependency.
 namespace ocpn { using String = std::string; }
+
+using wxString = std::string;
+using wxChar = char;
+
+#define wxT(x) x
+#define _T(x) x
+
+inline std::string wxStringToStdString(const wxString& s) { return s; }
+inline const char* wxCString(const wxString& s) { return s.c_str(); }
+
+// A trivial tokenizer used by some OpenCPN code paths.
+inline std::vector<std::string> wxStringTokenize(const wxString& s, const wxString& delim) {
+    std::vector<std::string> out;
+    size_t start = 0, end;
+    while ((end = s.find_first_of(delim, start)) != std::string::npos) {
+        out.push_back(s.substr(start, end - start));
+        start = end + 1;
+    }
+    out.push_back(s.substr(start));
+    return out;
+}

--- a/wrapper/shim/wx/arrstr.h
+++ b/wrapper/shim/wx/arrstr.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "wx.h"
+#include <vector>
+
+typedef std::vector<wxString> wxArrayString;

--- a/wrapper/shim/wx/filename.h
+++ b/wrapper/shim/wx/filename.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "wx.h"
+#include <string>
+
+class wxFileName {
+public:
+    wxFileName() = default;
+    explicit wxFileName(const wxString& p): path(p) {}
+    wxString GetFullPath() const { return path; }
+    bool IsRelative() const { return false; }
+private:
+    wxString path;
+};

--- a/wrapper/shim/wx/image.h
+++ b/wrapper/shim/wx/image.h
@@ -1,0 +1,3 @@
+#pragma once
+#include "wx.h"
+class wxImage { };

--- a/wrapper/shim/wx/mstream.h
+++ b/wrapper/shim/wx/mstream.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "wx.h"
+#include <sstream>
+
+class wxMemoryOutputStream {
+public:
+    std::ostringstream ss;
+    void Write(const void* data, size_t size) { ss.write(static_cast<const char*>(data), size); }
+};
+
+class wxMemoryInputStream {
+public:
+    wxMemoryInputStream(const char* data, size_t size) : ss(std::string(data, size)) {}
+    std::istringstream ss;
+};

--- a/wrapper/shim/wx/string.h
+++ b/wrapper/shim/wx/string.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "wx.h"

--- a/wrapper/shim/wx/textfile.h
+++ b/wrapper/shim/wx/textfile.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "wx.h"
+
+class wxTextFile {
+public:
+    bool Open(const wxString&){return true;}
+    void Close(){}
+    size_t GetLineCount() const {return lines.size();}
+    wxString GetLine(size_t i) const {return lines[i];}
+    void AddLine(const wxString& s){lines.push_back(s);}
+    std::vector<wxString> lines;
+};

--- a/wrapper/shim/wx/tokenzr.h
+++ b/wrapper/shim/wx/tokenzr.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "wx.h"
+class wxStringTokenizer {
+public:
+    wxStringTokenizer(const wxString& src, const wxString& delims)
+        : tokens(wxStringTokenize(src, delims)), pos(0) {}
+    bool HasMoreTokens() const { return pos < tokens.size(); }
+    wxString GetNextToken() { return tokens[pos++]; }
+private:
+    std::vector<wxString> tokens;
+    size_t pos;
+};

--- a/wrapper/shim/wx/wx.h
+++ b/wrapper/shim/wx/wx.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "../strings.hpp"
+#include "../log.hpp"
+#include <cassert>
+
+#define wxLogMessage(...) do { fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } while(0)
+#define wxLogError(...)   do { fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } while(0)
+#define wxASSERT(x) assert(x)

--- a/wrapper/shim/wx/wxprec.h
+++ b/wrapper/shim/wx/wxprec.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "wx.h"

--- a/wrapper/src/bbox.cpp
+++ b/wrapper/src/bbox.cpp
@@ -1,2 +1,1 @@
 #include "bbox.hpp"
-// placeholder implementation

--- a/wrapper/src/bbox.hpp
+++ b/wrapper/src/bbox.hpp
@@ -1,2 +1,9 @@
 #pragma once
-struct BBox { double minx, miny, maxx, maxy; };
+
+struct BBox {
+    double minx{0}, miny{0}, maxx{0}, maxy{0};
+    bool intersects(const BBox& other) const {
+        return !(other.minx > maxx || other.maxx < minx ||
+                 other.miny > maxy || other.maxy < miny);
+    }
+};

--- a/wrapper/src/main.cpp
+++ b/wrapper/src/main.cpp
@@ -1,13 +1,61 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <sstream>
 #include "emit_ndjson.hpp"
 #include "attr_codec.hpp"
 #include "bbox.hpp"
 
-int main(int argc, char** argv){
-    std::cout << "{\"type\":\"Dataset\"}\n";
-    // placeholder feature emission
-    std::cout << "{\"type\":\"Feature\"}\n";
+struct Args {
+    std::string mode;
+    std::string src;
+    BBox bbox;
+    bool has_bbox{false};
+    bool full_attrs{false};
+    bool gzip{false};
+};
+
+static void usage() {
+    std::cerr << "usage: ocpn_min <s57|cm93> --src PATH [--bbox minx,miny,maxx,maxy] [--full-attrs] [--gzip]\n";
+}
+
+static bool parse_bbox(const std::string& s, BBox& out) {
+    std::stringstream ss(s);
+    char comma;
+    if (ss >> out.minx >> comma >> out.miny >> comma >> out.maxx >> comma >> out.maxy)
+        return true;
+    return false;
+}
+
+static bool parse_args(int argc, char** argv, Args& a) {
+    if (argc < 4) return false;
+    a.mode = argv[1];
+    for (int i = 2; i < argc; ++i) {
+        std::string token = argv[i];
+        if (token == "--src" && i + 1 < argc) {
+            a.src = argv[++i];
+        } else if (token == "--bbox" && i + 1 < argc) {
+            a.has_bbox = parse_bbox(argv[++i], a.bbox);
+        } else if (token == "--full-attrs") {
+            a.full_attrs = true;
+        } else if (token == "--gzip") {
+            a.gzip = true;
+        } else {
+            return false;
+        }
+    }
+    return !a.mode.empty() && !a.src.empty();
+}
+
+int main(int argc, char** argv) {
+    Args args;
+    if (!parse_args(argc, argv, args)) {
+        usage();
+        return 10; // bad args
+    }
+
+    emit_line("{\"type\":\"Dataset\",\"driver\":\"" + args.mode + "\"}");
+    // Placeholder feature emission
+    emit_line("{\"type\":\"Feature\",\"id\":\"stub\"}");
     return 0;
 }

--- a/wrapper/vendor_filelist.cmake
+++ b/wrapper/vendor_filelist.cmake
@@ -7,3 +7,9 @@
 ../libs/iso8211/src/ddfrecordindex.cpp
 ../libs/iso8211/src/ddfsubfielddefn.cpp
 ../libs/iso8211/src/ddfutils.cpp
+../libs/s57-charts/src/ogrs57datasource.cpp
+../libs/s57-charts/src/ogrs57layer.cpp
+../libs/s57-charts/src/s57classregistrar.cpp
+../libs/s57-charts/src/s57featuredefns.cpp
+../libs/s57-charts/src/s57reader.cpp
+../libs/s57-charts/src/s57registrar_mgr.cpp


### PR DESCRIPTION
## Summary
- expand minimal ocpn wrapper build system and source stubs
- add wxWidgets shim headers and attribute/bbox helpers
- provide gzip-aware ingestion helper for s57/cm93 charts

## Testing
- `python -m py_compile VDR/s57_CM93map_import/ingest.py`
- `cmake -S wrapper -B wrapper/build`
- `cmake --build wrapper/build` *(fails: wx/spinctrl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a40e8da18c832ab96740f61a963eba