### PR TITLE
Add shim headers for missing wx and gdal deps

### DIFF
--- a/wrapper/shim/gdal/ogr_api.h
+++ b/wrapper/shim/gdal/ogr_api.h
@@ -1,0 +1,19 @@
+#pragma once
+
+enum OGRFieldType { OGR_INT, OGR_REAL, OGR_STR };
+
+class OGRGeometry {
+public:
+    virtual ~OGRGeometry() = default;
+};
+
+class OGRPoint : public OGRGeometry {
+public:
+    OGRPoint(double, double, double = 0.0) {}
+};
+
+class OGRMultiPoint : public OGRGeometry {
+public:
+    void addGeometry(OGRPoint*) {}
+    OGRGeometry* getGeometryRef(int) { return nullptr; }
+};

--- a/wrapper/shim/wx/listctrl.h
+++ b/wrapper/shim/wx/listctrl.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "wx.h"
+
+#define wxLC_REPORT 0
+#define wxLC_SINGLE_SEL 0
+#define wxLC_HRULES 0
+#define wxLC_VRULES 0
+#define wxLC_VIRTUAL 0
+#define wxBORDER_SUNKEN 0
+#define wxLIST_FORMAT_LEFT 0
+#define wxLIST_FORMAT_CENTER 0
+#define wxLIST_STATE_SELECTED 0
+#define wxEVT_COMMAND_LIST_ITEM_SELECTED 0
+#define wxListEventHandler(x) x
+
+class wxListEvent {};
+
+class wxListCtrl {
+public:
+    wxListCtrl(...) {}
+    void Connect(...) {}
+    void InsertColumn(...) {}
+    void InsertItem(...) {}
+    void SetItem(...) {}
+    void SetItemCount(...) {}
+    void SetItemState(...) {}
+    void DeleteAllItems() {}
+    void Refresh(...) {}
+    long GetItemCount() const { return 0; }
+    bool IsVirtual() const { return false; }
+};

--- a/wrapper/shim/wx/regex.h
+++ b/wrapper/shim/wx/regex.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "wx.h"
+#include <regex>
+
+class wxRegEx {
+public:
+    wxRegEx(const wxString& pattern) : re(pattern) {}
+    bool Matches(const wxString& text) const {
+        return std::regex_match(text, re);
+    }
+private:
+    std::regex re;
+};

--- a/wrapper/shim/wx/spinctrl.h
+++ b/wrapper/shim/wx/spinctrl.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "wx.h"
+
+class wxSpinCtrl {
+public:
+    wxSpinCtrl(...) {}
+    void Connect(...) {}
+    int GetValue() const { return 0; }
+    void SetValue(int) {}
+};


### PR DESCRIPTION
## Summary
- add minimal wx shim headers for spin and list controls
- stub regex and GDAL OGR API used by vendored cm93 sources

## Testing
- `cmake --build build` *(fails: s52s57.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4178b1a1c832a8e8fffcebcabdc92