### PR TITLE
Add stub s52s57 header for wrapper build

### DIFF
--- a/wrapper/shim/s52s57.h
+++ b/wrapper/shim/s52s57.h
@@ -1,0 +1,22 @@
+#ifndef OCPN_MIN_S52S57_H
+#define OCPN_MIN_S52S57_H
+
+#include <vector>
+
+struct LUPrec;
+struct S57Obj;
+struct sm_parms;
+struct mps_container;
+
+struct ObjRazRules {
+    LUPrec* LUP = nullptr;
+    S57Obj* obj = nullptr;
+    sm_parms* sm_transform_parms = nullptr;
+    ObjRazRules* child = nullptr;
+    ObjRazRules* next = nullptr;
+    mps_container* mps = nullptr;
+};
+
+using ListOfObjRazRules = std::vector<ObjRazRules*>;
+
+#endif // OCPN_MIN_S52S57_H


### PR DESCRIPTION
## Summary
- stub `s52s57.h` with minimal structs to satisfy missing header during wrapper compilation

## Testing
- `cmake -S wrapper -B wrapper/build`
- `cmake --build wrapper/build`


------
https://chatgpt.com/codex/tasks/task_e_68a42f68a208832aaf94a3a34d1559de