### PR TITLE
Add gitignore to s57_CM93map_import test data directory

### DIFF
--- a/VDR/s57_CM93map_import/testdata/.gitignore
+++ b/VDR/s57_CM93map_import/testdata/.gitignore
@@ -1,3 +1,3 @@
 *
-!README.md
 !.gitignore
+!README.md


### PR DESCRIPTION
## Summary
- ensure test data directory only tracks placeholder files

## Testing
- `cd VDR/s57_CM93map_import && ./tools/build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a502cbc58c832a9bd17b96afea2821